### PR TITLE
Fixes bower_components directory resolve issue

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory": "bower_components"
+}


### PR DESCRIPTION
Without this, `bower install` puts dependencies under `app/components`, which causes a `npm run build` failure. On Fedora 25, npm 4.4.1, bower 1.8.0.

cc @spadgett @jwforres @jeff-phillips-18 