### PR TITLE
Fixes for retriving real and mock serviceclasses

### DIFF
--- a/app/mockServices/mockData.service.ts
+++ b/app/mockServices/mockData.service.ts
@@ -5,6 +5,18 @@ interface IDataService {
   list(resource: any, context: any, callback: any, opts: any) : angular.IPromise < any >;
 }
 
+class Data {
+  private _data: any;
+
+  constructor (array: any) {
+    this._data = array;
+  }
+
+  public by (attr: string) {
+    return this._data;
+  }
+}
+
 export class DataService implements IDataService {
   public static $inject = ['$q'];
 
@@ -23,7 +35,7 @@ export class DataService implements IDataService {
     switch (resource.resource) {
       case 'serviceclasses':
           setTimeout(() => {
-            deferred.resolve(servicesData);
+            deferred.resolve(new Data(servicesData));
           }, 300);
         break;
     }

--- a/app/pages/home/homePageController.ts
+++ b/app/pages/home/homePageController.ts
@@ -30,7 +30,7 @@ export class HomePageController {
         group: 'servicecatalog.k8s.io',
         resource: 'serviceclasses'
       }, {}, (resources: any) => {
-        this.ctrl.services = resources;
+        this.ctrl.services = resources.by("metadata.name"); ;
         this.ctrl.applications = this.constants.REDHAT_APPLICATIONS;
         this.ctrl.categories = this.constants.SERVICE_CATALOG_CATEGORIES;
         this.ctrl.loading = false;


### PR DESCRIPTION
Final tweeks to truly be able to switch between mock and real retrieval of serviceclasses from Service Catalog API.