### PR TITLE
Add visual styles to search

### DIFF
--- a/dist/origin-web-catalogs.css
+++ b/dist/origin-web-catalogs.css
@@ -37,6 +37,9 @@
 .landing-main-area {
   background-color: #3ca2c9;
 }
+.landing-main-area h1 {
+  margin-left: 20px;
+}
 @media (min-width: 768px) {
   .landing-main-area {
     margin-right: 325px;
@@ -52,6 +55,15 @@
     margin-right: 450px;
   }
 }
+.landing-search-area {
+  border-bottom: solid 1px #7dc3e8;
+  padding: 10px;
+}
+@media (min-width: 768px) {
+  .landing-search-area {
+    padding: 13.33333333px;
+  }
+}
 .landing-search-form {
   margin: 0 auto;
   width: 100%;
@@ -62,12 +74,26 @@
     width: 80%;
   }
 }
+.landing-search-form .search-pf-input-group .form-control {
+  font-size: 14px;
+  height: 2.2em;
+}
+.landing-search-form .search-pf-input-group .pficon-close {
+  font-size: 16px;
+  padding-top: .3em;
+}
 .landing-search-form .dropdown-menu {
   width: 100%;
 }
 .landing-search-form .dropdown-menu > li > a.catalog-search-match {
   padding-bottom: 5px;
   padding-top: 5px;
+}
+.landing-search-form .dropdown-menu .active > a.catalog-search-match,
+.landing-search-form .dropdown-menu :focus {
+  background-color: #def3ff !important;
+  border-color: #bee1f4 !important;
+  color: inherit !important;
 }
 .catalog-search-match {
   height: 45px;

--- a/src/styles/landing-page.less
+++ b/src/styles/landing-page.less
@@ -1,6 +1,9 @@
 .landing-main-area {
-  background-color: @landing-main-bg;
+  h1 {  // This is Temp
+    margin-left: @grid-gutter-width / 2;
+  }
 
+  background-color: @landing-main-bg;
   @media(min-width: @screen-sm-min) {
     margin-right: @landing-side-bar-width-sm;
   }
@@ -12,6 +15,13 @@
   }
 }
 
+.landing-search-area {
+  border-bottom: solid 1px @color-pf-blue-200;
+  padding: (@grid-gutter-width / 4);
+  @media (min-width: @screen-sm-min) {
+    padding: (@grid-gutter-width / 3);
+  }
+}
 .landing-search-form {
   margin: 0 auto;
   width: 100%;
@@ -19,12 +29,28 @@
     max-width: 600px;
     width: 80%;
   }
+  .search-pf-input-group{
+    .form-control{
+      font-size: (@font-size-base + 2);
+      height: 2.2em;
+    }
+    .pficon-close {
+      font-size: (@font-size-base + 4);
+      padding-top: .3em;
+    }
+  }
   .dropdown-menu {
     width: 100%;
     // Styles need to be specific enough to override defaults.
     > li > a.catalog-search-match {
       padding-bottom: 5px;
       padding-top: 5px;
+    }
+    // important needed to override styles declared important in PatternFly
+    .active > a.catalog-search-match, :focus{
+      background-color: @color-pf-blue-50 !important;
+      border-color: @color-pf-blue-100 !important;
+      color: inherit !important;
     }
   }
 }

--- a/src/styles/variables.less
+++ b/src/styles/variables.less
@@ -2,11 +2,11 @@
 @import '~patternfly/dist/less/color-variables.less';
 @import '~patternfly/dist/less/variables.less';
 
+@landing-main-bg:                                     #3ca2c9;
 @landing-side-bar-bg:                                 #2C343D;
 @landing-side-bar-top-offset:                         72px;
 @landing-side-bar-width-sm:                           325px;
 @landing-side-bar-width-md:                           375px;
 @landing-side-bar-width-lg:                           450px;
-@landing-main-bg: #3ca2c9;
-@saas-text: @color-pf-white;
-@saas-hover: fade(@color-pf-blue-600, 80%);
+@saas-hover:                                          fade(@color-pf-blue-600, 80%);
+@saas-text:                                           @color-pf-white;


### PR DESCRIPTION
Visual updates to landing page search bar. Does not include css to make the search bar sticky.

<img width="608" alt="screen shot 2017-04-05 at 2 52 16 pm" src="https://cloud.githubusercontent.com/assets/3300756/24722081/5da85500-1a10-11e7-9b9c-ff3988e04bd6.png">
