### PR TITLE
Fixes #87 - The <select-project> component shows offset highlight when selecting a project

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
     "patternfly": "3.21.0",
     "jquery": "2.1.4",
     "lodash": "3.10.1",
-    "origin-web-common": "^0.0.10"
+    "origin-web-common": "0.x"
   },
   "devDependencies": {
     "ace-builds": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "bootstrap": "^3.3.6",
     "font-awesome": "^4.6.1",
     "jquery": "~2.1.4",
-    "origin-web-common": "^0.0.10",
+    "origin-web-common": "0.x",
     "paper-css": "^0.1.2",
     "patternfly": "3.20.0",
     "urijs": "1.18.0"


### PR DESCRIPTION
Changed semantic versioning to retrieve all origin-web-common 0.0 minor versions
This picks up origin-web-common@0.0.11 which contains the ui-select styles for the `<select-project>` component.