### PR TITLE
Sort catalog items

### DIFF
--- a/dist/origin-web-catalogs.js
+++ b/dist/origin-web-catalogs.js
@@ -1069,12 +1069,16 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             this.ctrl.loading = s.isEmpty(this.ctrl.serviceClasses) && !this.serviceClassesLoaded || s.isEmpty(this.ctrl.imageStreams) && !this.imageStreamsLoaded, 
             this.ctrl.loading || (this.ctrl.filteredItems = this.ctrl.allItems, this.ctrl.categories = this.catalog.removeEmptyCategories(this.ctrl.filteredItems), 
             this.ctrl.subCategories = this.getSubCategories("all"));
+        }, e.prototype.sort = function(e) {
+            return s.sortByAll(e, [ function(e) {
+                return e.name.toLowerCase();
+            }, "resource.kind", "resource.metadata.name" ]);
         }, e.prototype.updateServiceClasses = function() {
-            this.ctrl.allItems = this.ctrl.allItems.concat(this.normalizeData("service", this.ctrl.serviceClasses)), 
-            this.updateState();
+            var e = this.ctrl.allItems.concat(this.normalizeData("service", this.ctrl.serviceClasses));
+            this.ctrl.allItems = this.sort(e), this.updateState();
         }, e.prototype.updateImageStreams = function() {
-            this.ctrl.allItems = this.ctrl.allItems.concat(this.normalizeData("image", this.ctrl.imageStreams)), 
-            this.updateState();
+            var e = this.ctrl.allItems.concat(this.normalizeData("image", this.ctrl.imageStreams));
+            this.ctrl.allItems = this.sort(e), this.updateState();
         }, e.prototype.resizeExpansion = function() {
             var e = a(".sub-cat-card.active"), t = e.find(".card-view-pf").outerHeight();
             e.css("margin-bottom", t + "px");

--- a/src/components/services-view/services-view.controller.ts
+++ b/src/components/services-view/services-view.controller.ts
@@ -147,13 +147,21 @@ export class ServicesViewController implements angular.IController {
     }
   }
 
+  private sort(items: any[]) {
+    // Perform a case-insensitive sort on display name, falling back to kind
+    // and metadata.name for a stable sort when items have the same display name.
+    return _.sortByAll(items, [(item) => item.name.toLowerCase(), 'resource.kind', 'resource.metadata.name']);
+  }
+
   private updateServiceClasses() {
-    this.ctrl.allItems = this.ctrl.allItems.concat(this.normalizeData('service', this.ctrl.serviceClasses));
+    let allItems = this.ctrl.allItems.concat(this.normalizeData('service', this.ctrl.serviceClasses));
+    this.ctrl.allItems = this.sort(allItems);
     this.updateState();
   }
 
   private updateImageStreams() {
-    this.ctrl.allItems = this.ctrl.allItems.concat(this.normalizeData('image', this.ctrl.imageStreams));
+    let allItems = this.ctrl.allItems.concat(this.normalizeData('image', this.ctrl.imageStreams));
+    this.ctrl.allItems = this.sort(allItems);
     this.updateState();
   }
 


### PR DESCRIPTION
Sort subcategory items. Currently, sometimes the builders appear first and sometimes the service classes appear first. They should be sorted as one list by display name.