### PR TITLE
Remove unnecessary styles from search results

### DIFF
--- a/dist/origin-web-catalogs.css
+++ b/dist/origin-web-catalogs.css
@@ -34,9 +34,6 @@
     opacity: 0;
   }
 }
-.catalog-search-match {
-  height: 45px;
-}
 .catalog-search-match .catalog-search-match-info {
   display: inline-block;
   vertical-align: top;
@@ -119,10 +116,6 @@
 .landing-search-form .dropdown-menu {
   margin-top: 0;
   width: 100%;
-}
-.landing-search-form .dropdown-menu > li > a.catalog-search-match {
-  padding-bottom: 5px;
-  padding-top: 5px;
 }
 .landing-search-form .dropdown-menu .active > a.catalog-search-match,
 .landing-search-form .dropdown-menu :focus {

--- a/src/styles/landing-page.less
+++ b/src/styles/landing-page.less
@@ -1,5 +1,4 @@
 .catalog-search-match {
-  height: 45px;
   .catalog-search-match-info {
     display: inline-block;
     vertical-align: top;
@@ -80,11 +79,6 @@
   .dropdown-menu {
     margin-top: 0;
     width: 100%;
-    // Styles need to be specific enough to override defaults.
-    > li > a.catalog-search-match {
-      padding-bottom: 5px;
-      padding-top: 5px;
-    }
     // important needed to override styles declared important in PatternFly
     .active > a.catalog-search-match, :focus{
       background-color: @color-pf-blue-50 !important;


### PR DESCRIPTION
The typeahead dropdown was using some styles that aren't needed and
caused some minor visual problems when integrated in the console.

Fixes this issue:

<img width="527" alt="screen shot 2017-04-08 at 1 50 06 pm" src="https://cloud.githubusercontent.com/assets/1167259/24831153/679f99e8-1c62-11e7-9228-670b9475107d.png">
