### PR TITLE
Remove unnecessary top padding from header

### DIFF
--- a/dist/origin-web-catalogs.css
+++ b/dist/origin-web-catalogs.css
@@ -61,9 +61,6 @@
   margin-right: 5px;
   text-transform: uppercase;
 }
-.landing-header-area {
-  padding-top: 50.4px;
-}
 @media (min-width: 768px) {
   .landing-header-area {
     padding-top: 57.06666667px;

--- a/src/styles/landing-page.less
+++ b/src/styles/landing-page.less
@@ -26,11 +26,9 @@
   }
 }
 
-.landing-header-area {
-  // Height of search bar plus padding of search bar
-  padding-top: ((2.2 * @font-size-base + 4) + (2 * (@grid-gutter-width / 4)));
-
-  @media (min-width: @screen-sm-min) {
+@media (min-width: @screen-sm-min) {
+  .landing-header-area {
+    // Height of search bar plus padding of search bar
     padding-top: ((2.2 * @font-size-base + 4) + (2 * (@grid-gutter-width / 3)));
   }
 }


### PR DESCRIPTION
There is extra padding at mobile sizes to account for a fixed search bar, but the search bar is no longer fixed at mobile.

Fixes #110