### PR TITLE
Default to `project/` for base project URL

### DIFF
--- a/dist/origin-web-catalogs.js
+++ b/dist/origin-web-catalogs.js
@@ -294,7 +294,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
     "use strict";
     function r() {
         return function(e, t) {
-            var n = t || "", r = e && e.metadata ? e.metadata.name : "";
+            var n = t || "project/", r = e && e.metadata ? e.metadata.name : "";
             return n.endsWith("/") || (n += "/"), n + r;
         };
     }

--- a/src/filters/projectUrl.ts
+++ b/src/filters/projectUrl.ts
@@ -1,7 +1,7 @@
 export function projectUrlFilter () {
 
   return function(project: any, base: any) {
-    var baseUrl: string = base || '';
+    var baseUrl: string = base || 'project/';
     var projectName : string =  (project && project.metadata) ? project.metadata.name : '';
 
     if (!baseUrl.endsWith('/')) {


### PR DESCRIPTION
Default to relative URL `project/` instead of `/` for the default base URL. This will work correctly when running in the web console.