### PR TITLE
Consolidated retrieval of Catalog Service Items

### DIFF
--- a/app/pages/home/home-page.html
+++ b/app/pages/home/home-page.html
@@ -1,6 +1,6 @@
 <landing-page>
   <landingsearch>
-    <catalog-search service-classes="$ctrl.serviceClasses" image-streams="$ctrl.imageStreams" base-project-url="{{$ctrl.baseProjectUrl}}"></catalog-search>
+    <catalog-search catalog-items="$ctrl.catalogItems" base-project-url="{{$ctrl.baseProjectUrl}}"></catalog-search>
   </landingsearch>
   <landingheader>
     <div class="build-applications-view">
@@ -8,9 +8,9 @@
     </div>
   </landingheader>
   <landingbody>
-    <services-view service-classes="$ctrl.serviceClasses" image-streams="$ctrl.imageStreams" base-project-url="{{$ctrl.baseProjectUrl}}"></services-view>
+    <services-view catalog-items="$ctrl.catalogItems" base-project-url="{{$ctrl.baseProjectUrl}}"></services-view>
   </landingbody>
   <landingside>
-    <projects-summary service-classes="$ctrl.serviceClasses" image-streams="$ctrl.imageStreams" base-project-url="{{$ctrl.baseProjectUrl}}" projects-url="{{$ctrl.projectsUrl}}"></projects-summary>
+    <projects-summary catalog-items="$ctrl.catalogItems" base-project-url="{{$ctrl.baseProjectUrl}}" projects-url="{{$ctrl.projectsUrl}}"></projects-summary>
   </landingside>
 </landing-page>

--- a/app/pages/home/homePageController.ts
+++ b/app/pages/home/homePageController.ts
@@ -1,25 +1,17 @@
 export class HomePageController {
-  static $inject = ['$state', 'AuthService', 'Logger', 'Constants', 'DataService'];
+  static $inject = ['$state', 'AuthService', 'Catalog', 'Constants'];
 
   public ctrl: any = this;
   private $state: any;
   private authService: any;
-  private logger: any;
+  private Catalog: any;
   private constants: any;
-  private dataService: any;
-  private Logger: any;
 
-  constructor($state: any, AuthService: any, Logger: any, Constants: any, DataService: any) {
+  constructor($state: any, AuthService: any, Catalog: any, Constants: any) {
     this.$state = $state;
     this.authService = AuthService;
-    this.logger = Logger;
+    this.Catalog = Catalog;
     this.constants = Constants;
-    this.dataService = DataService;
-    this.Logger = Logger;
-    this.ctrl.applications = [];
-    this.ctrl.categories = [];
-    this.ctrl.serviceClasses = {};
-    this.ctrl.imageStreams = {};
   };
 
   public $onInit() {
@@ -33,21 +25,10 @@ export class HomePageController {
   };
 
   public update() {
-    this.dataService.list({
-      group: 'servicecatalog.k8s.io',
-      resource: 'serviceclasses'
-    }, {}).then( (resources: any) => {
-      this.ctrl.serviceClasses = resources.by("metadata.name");
+    this.Catalog.getCatalogItems().then( (catalogServiceItems: any) => {
+      this.ctrl.catalogItems = catalogServiceItems;
     }, () => {
-      this.logger.log("Error Loading serviceclasses from servicecatalog.k8s.io: ");
-      this.ctrl.serviceClasses = {};
-    });
-
-    this.dataService.list("imagestreams", {namespace: "openshift"}).then( (resources: any) => {
-      this.ctrl.imageStreams = resources.by("metadata.name");
-    }, () => {
-      this.logger.log("Error Loading openshift imagestreams: ");
-      this.ctrl.imageStreams = {};
+      this.ctrl.catalogItems = {};
     });
 
     this.ctrl.saasOfferings = this.constants.SAAS_OFFERINGS;

--- a/src/components/catalog-search/catalog-search.component.ts
+++ b/src/components/catalog-search/catalog-search.component.ts
@@ -3,8 +3,7 @@ import {CatalogSearchController} from './catalog-search.controller';
 export const catalogSearch: angular.IComponentOptions = {
   bindings: {
     baseProjectUrl: '@',
-    imageStreams: '<',
-    serviceClasses: '<'
+    catalogItems: '<'
   },
   controller: CatalogSearchController,
   template: require('./catalog-search.html')

--- a/src/components/catalog-search/catalog-search.controller.ts
+++ b/src/components/catalog-search/catalog-search.controller.ts
@@ -7,7 +7,6 @@ export class CatalogSearchController implements angular.IController {
 
   private Catalog: any;
   private KeywordService: any;
-  private allItems: any[];
   private $scope: any;
   private $q: any;
   private loaded: boolean = false;
@@ -26,27 +25,8 @@ export class CatalogSearchController implements angular.IController {
   }
 
   public $onChanges(onChangesObj: angular.IOnChangesObject) {
-    if (onChangesObj.serviceClasses || onChangesObj.imageStreams) {
-      if (!this.ctrl.serviceClasses && !this.ctrl.imageStreams) {
-        return;
-      }
+    if (onChangesObj.catalogItems && this.ctrl.catalogItems) {
 
-      // Convert service classes to ServiceItem, which is needed for the ordering panel.
-      let items = _.map(this.ctrl.serviceClasses, (serviceClass) => {
-        return this.Catalog.getServiceItem(serviceClass);
-      });
-
-      // Convert builders to ImageItem.
-      items = items.concat(_.map(this.ctrl.imageStreams, (imageStream) => {
-        return this.Catalog.getImageItem(imageStream);
-      }));
-
-      // Remove null items (non-builder images).
-      items = _.reject(items, (item) => {
-        return !item;
-      });
-
-      this.allItems = _.sortBy(items, 'name');
       this.loaded = true;
 
       // Show search results now if the user began typing before the items loaded.
@@ -79,7 +59,7 @@ export class CatalogSearchController implements angular.IController {
 
   private filterForKeywords(searchText: string) {
     let keywords = this.KeywordService.generateKeywords(searchText);
-    let items = this.KeywordService.filterForKeywords(this.allItems, ['name', 'tags', 'resource.osbTags'], keywords);
+    let items = this.KeywordService.filterForKeywords(this.ctrl.catalogItems, ['name', 'tags', 'resource.osbTags'], keywords);
     return _.take(items, 5);
   }
 }

--- a/src/components/projects-summary/projects-summary.component.ts
+++ b/src/components/projects-summary/projects-summary.component.ts
@@ -2,9 +2,8 @@ import {ProjectsSummaryController} from './projects-summary.controller';
 
 export const projectsSummary: angular.IComponentOptions = {
   bindings: {
-    imageStreams: '<',
-    serviceClasses: '<',
     baseProjectUrl: '@',
+    catalogItems: '<',
     projectsUrl: '@',
     viewEditMembership: '&',
     startGettingStartedTour: '&'

--- a/src/components/projects-summary/projects-summary.controller.ts
+++ b/src/components/projects-summary/projects-summary.controller.ts
@@ -135,27 +135,8 @@ export class ProjectsSummaryController implements angular.IController {
   };
 
   public $onChanges(onChangesObj: angular.IOnChangesObject) {
-    if (onChangesObj.serviceClasses || onChangesObj.imageStreams) {
-      if (!this.ctrl.serviceClasses && !this.ctrl.imageStreams) {
-        return;
-      }
-
-      // Convert service classes to ServiceItem, which is needed for the ordering panel.
-      let items = _.map(this.ctrl.serviceClasses, (serviceClass) => {
-        return this.Catalog.getServiceItem(serviceClass);
-      });
-
-      // Convert builders to ImageItem.
-      items = items.concat(_.map(this.ctrl.imageStreams, (imageStream) => {
-        return this.Catalog.getImageItem(imageStream);
-      }));
-
-      // Remove null items (non-builder images).
-      items = _.reject(items, (item) => {
-        return !item;
-      });
-
-      this.allItems = _.indexBy(items, 'resource.metadata.uid');
+    if (onChangesObj.catalogItems && this.ctrl.catalogItems) {
+      this.allItems = _.indexBy(this.ctrl.catalogItems, 'resource.metadata.uid');
       this.ctrl.recentlyViewedItems = this.getRecentlyViewedItems();
     }
   }

--- a/src/components/services-view/services-view.component.ts
+++ b/src/components/services-view/services-view.component.ts
@@ -3,8 +3,7 @@ import {ServicesViewController} from './services-view.controller';
 export const servicesView: angular.IComponentOptions = {
   bindings: {
     baseProjectUrl: '@',
-    serviceClasses: '<',
-    imageStreams: '<'
+    catalogItems: '<',
   },
   controller: ServicesViewController,
   template: require('./services-view.html')

--- a/src/components/services-view/services-view.html
+++ b/src/components/services-view/services-view.html
@@ -1,8 +1,8 @@
 <div class="services-view">
-  <div ng-if="$ctrl.loading" class="spinner-container">
-    <div ng-class="{'spinner spinner-xl': $ctrl.loading}"></div>
+  <div ng-if="!$ctrl.loaded" class="spinner-container">
+    <div class="spinner spinner-xl"></div>
   </div>
-  <div ng-if="!$ctrl.loading" class="services-view-container">
+  <div ng-if="$ctrl.loaded" class="services-view-container">
     <h1>Browse Catalog</h1>
 
     <ul class="nav nav-tabs nav-tabs-pf">
@@ -52,6 +52,7 @@
     <div ng-if="$ctrl.currentFilter === 'other' || $ctrl.currentFilter === 'all'" class="services-items">
       <div class="services-items-inner">
         <div class="services-items-inner-shadow-covers">
+          <div ng-if="$ctrl.isEmpty">There are no catalog items.</div>
           <a href="" class="services-item" ng-repeat="item in $ctrl.filteredItems" ng-click="$ctrl.handleClick(item)">
             <div ng-if="!item.imageUrl" class="services-item-icon">
               <span class="{{item.iconClass}}"></span>

--- a/test/projects-summary.spec.ts
+++ b/test/projects-summary.spec.ts
@@ -21,8 +21,10 @@ describe('Projects Summary Panel', () => {
   var $window: any;
   var $q: any;
   var ProjectsService: any;
+  var Catalog: any;
   var DataService: any;
   var RecentlyViewed: any;
+  var catalogItems: any;
   var services: any;
   var images: any;
   var viewMembershipProject: any;
@@ -62,17 +64,15 @@ describe('Projects Summary Panel', () => {
 
   var createProjectSummary = function() {
     var projectsSummaryHtml: string = '<projects-summary ' +
-      'service-classes="services" ' +
-      'image-streams="images" ' +
-      'view-edit-membership="testViewMembership" ' +
-      'start-getting-started-tour="testShowTour">' +
+        'catalog-items="catalogItems" ' +
+        'view-edit-membership="testViewMembership" ' +
+        'start-getting-started-tour="testShowTour">' +
       '</projects-summary>';
 
     componentTest = new ComponentTest<ProjectsSummaryController>(projectsSummaryHtml);
 
     var attributes: any = {
-      services: services,
-      images: images,
+      catalogItems: catalogItems,
       testViewMembership: testViewMembership,
       testShowTour: testShowTour,
     };
@@ -87,11 +87,12 @@ describe('Projects Summary Panel', () => {
   });
 
   beforeEach(() => {
-    inject(function (_$window_: any, _$timeout_: any, _$q_: any, _ProjectsService_: any, _DataService_: any, _RecentlyViewedServiceItems_: any) {
+    inject(function (_$window_: any, _$timeout_: any, _$q_: any, _ProjectsService_: any, _Catalog_: any, _DataService_: any, _RecentlyViewedServiceItems_: any) {
       $window = _$window_;
       $timeout = _$timeout_;
       $q = _$q_;
       ProjectsService = _ProjectsService_;
+      Catalog = _Catalog_;
       DataService = _DataService_;
       RecentlyViewed = _RecentlyViewedServiceItems_;
     });
@@ -101,6 +102,7 @@ describe('Projects Summary Panel', () => {
     expectedCanCreate = true;
     services = angular.copy(servicesData);
     images = angular.copy(imagesData);
+    catalogItems = Catalog.convertToServiceItems(services, images);
 
     spyOn(ProjectsService, 'canCreate').and.callFake(function() {
       let deferred = this.$q.defer();

--- a/test/services-view.spec.ts
+++ b/test/services-view.spec.ts
@@ -9,8 +9,10 @@ import {imagesData} from '../app/mockServices/mockData/openshift-images';
 
 describe('servicesView', () => {
   var services: any, images: any;
+  var catalogItems: any;
   var componentTest: ComponentTest<ServicesViewController>;
   var testHelpers: TestHelpers = new TestHelpers();
+  var Catalog: any;
 
   beforeEach( () => {
     testHelpers.initTests();
@@ -19,15 +21,22 @@ describe('servicesView', () => {
   });
 
   beforeEach(() => {
+    inject(function (_Catalog_: any) {
+      Catalog = _Catalog_;
+    });
+  });
+
+  beforeEach(() => {
     services = angular.copy(servicesData);
     images = angular.copy(imagesData);
+    catalogItems = Catalog.convertToServiceItems(services, images);
   });
 
   beforeEach(() => {
     componentTest = new ComponentTest<ServicesViewController>(
-        '<services-view service-classes=\"services\" image-streams=\"images\"></services-view>'
+        '<services-view catalog-items="catalogItems"></services-view>'
     );
-    var attributes: any = { services: services, images: images};
+    var attributes: any = {catalogItems: catalogItems};
     componentTest.createComponent(attributes);
   });
 
@@ -40,6 +49,7 @@ describe('servicesView', () => {
 
   it('should display the initial categories and correct number of catalog cards', () => {
     var element = componentTest.rawElement;
+
     // 4 main categories ('All', 'Languages', 'Databases', 'Other')
     // 'Middleware' should be hidden since mock data has no items with Middleware sub-categories
     expect(jQuery(element).find('.nav-tabs-pf a').length).toBe(5);


### PR DESCRIPTION
In `<catalog-search>`, `<services-view>`, and `<projects-summary>` replaced attributes `service-classes` and `image-streams` with a single attribute `catalog-service-items`.  `catalog-items` are retrieved via `CatalogServices` class.  

This PR basically removes a bunch of data normalization functions, which were duplicated in the three components listed above, and centralizes them in CatalogServices. 