### PR TITLE
Remove unnecessary exports from Constants

### DIFF
--- a/dist/origin-web-catalogs.js
+++ b/dist/origin-web-catalogs.js
@@ -262,8 +262,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             label: "Other"
         } ]
     } ];
-    t.allCategories = i, t.allSaasOfferings = a, r.set(window, "OPENSHIFT_CONSTANTS.SERVICE_CATALOG_CATEGORIES", i), 
-    r.set(window, "OPENSHIFT_CONSTANTS.SAAS_OFFERINGS", a);
+    r.set(window, "OPENSHIFT_CONSTANTS.SERVICE_CATALOG_CATEGORIES", i), r.set(window, "OPENSHIFT_CONSTANTS.SAAS_OFFERINGS", a);
     var c = {
         links: [ {
             title: "Documentation",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -48,9 +48,6 @@ var categories: any = [
   ]}
 ];
 
-export const allCategories = categories;
-export const allSaasOfferings = saasOfferings;
-
 _.set(window, 'OPENSHIFT_CONSTANTS.SERVICE_CATALOG_CATEGORIES', categories);
 _.set(window, 'OPENSHIFT_CONSTANTS.SAAS_OFFERINGS', saasOfferings);
 

--- a/test/saas-list.spec.ts
+++ b/test/saas-list.spec.ts
@@ -5,20 +5,27 @@ import 'angular-mocks';
 import {TestHelpers} from '../test/utils/testHelpers';
 import {ComponentTest} from '../test/utils/ComponentTest';
 import {SaasListController} from '../src/components/saas-list/saas-list.controller';
-import {allSaasOfferings} from '../src/constants';
 
 describe('saasOfferingsList', () => {
   var saasOfferings: any, saasTitle: string;
   var componentTest: ComponentTest<SaasListController>;
   var testHelpers: TestHelpers = new TestHelpers();
+  var Constants: any;
 
   beforeEach( () => {
     testHelpers.initTests();
-    angular.mock.module('webCatalog');
+
+    angular.mock.module('webCatalog', 'openshiftCommonUI', 'mockServices');
   });
 
   beforeEach(() => {
-    saasOfferings = angular.copy(allSaasOfferings);
+    inject(function (_Constants_: any) {
+      Constants = _Constants_;
+    });
+  });
+
+  beforeEach(() => {
+    saasOfferings = angular.copy(Constants.SAAS_OFFERINGS);
     saasTitle = 'What do you want to build?';
   });
 


### PR DESCRIPTION
Some dependency update causes the build to fail do to exporting from an non-module based file. The exports were included only to allow easy access from the test specs.

Removed the exports and updated the test spec to use the constants appropriately.