### PR TITLE
Making only right side panel contents scrollable, left side panel content clip

### DIFF
--- a/dist/less/catalog.less
+++ b/dist/less/catalog.less
@@ -2,6 +2,7 @@
 
 @import './animations.less';
 @import './landing-page.less';
+@import './mixins.less';
 @import './order-service.less';
 @import './overlay-panel.less';
 @import './projects-summary';

--- a/dist/less/mixins.less
+++ b/dist/less/mixins.less
@@ -1,0 +1,25 @@
+.scroll-shadows-horizontal(@shadow-width: 75%, @shadow-opacity: 0.2) {
+  background-attachment: scroll;
+  background-image: radial-gradient(ellipse at top, rgba(0, 0, 0, @shadow-opacity) 0%, rgba(0, 0, 0, 0) @shadow-width), radial-gradient(ellipse at bottom, rgba(0, 0, 0, @shadow-opacity) 0%, rgba(0, 0, 0, 0) @shadow-width);
+  background-position: 0 0, 0 100%;
+  background-repeat: no-repeat;
+  background-size: 100% 6px;
+}
+
+.scroll-shadows-horizontal-covers(@shadow-cover-bg-color: rgba(255,255,255,1), @shadow-cover-bg-color-transparent: rgba(255,255,255,0)) {
+  background-attachment: local;
+  background-image: linear-gradient(@shadow-cover-bg-color 30%, @shadow-cover-bg-color-transparent), linear-gradient(@shadow-cover-bg-color-transparent, @shadow-cover-bg-color 70%);
+  background-position: 0 0, 0 100%;
+  background-repeat: no-repeat;
+  background-size: 100% 12px;
+}
+
+.scroll-shadows-horizontal-with-covers(@shadow-width: 75%, @shadow-opacity: 0.2, @shadow-cover-bg-color: rgba(255,255,255,1), @shadow-cover-bg-color-transparent: rgba(255,255,255,0)) {
+  background-attachment: local, local, scroll, scroll;
+  background-image:
+    linear-gradient(@shadow-cover-bg-color 30%, @shadow-cover-bg-color-transparent), linear-gradient(@shadow-cover-bg-color-transparent, @shadow-cover-bg-color 70%),
+    radial-gradient(ellipse at top, rgba(0, 0, 0, @shadow-opacity) 0%, rgba(0, 0, 0, 0) @shadow-width), radial-gradient(ellipse at bottom, rgba(0, 0, 0, @shadow-opacity) 0%, rgba(0, 0, 0, 0) @shadow-width);
+  background-position: 0 0, 0 100%;
+  background-repeat: no-repeat;
+  background-size: 100% 12px, 100% 12px, 100% 6px, 100% 6px;
+}

--- a/dist/less/order-service.less
+++ b/dist/less/order-service.less
@@ -1,83 +1,29 @@
 // Breakpoint for showing a smaller icon and service title.
 @order-service-title-sm-min: 450px;
 
-.order-service-details {
-  flex: 0 1 auto;
-  padding: 0 (@grid-gutter-width / 2);
-  @media (min-width: @screen-sm-min) {
-    border-right: 1px solid @color-pf-black-400;
-    width: 50%;
-  }
-  .order-service-details-top {
-    align-items: center;
-    display: flex;
-    .service-icon {
-      margin-right: 15px;
-      .icon {
-        font-size: 60px;
-        @media (min-width: @order-service-title-sm-min) {
-          font-size: 64px;
-        }
-      }
-      .image {
-        img {
-          max-height: 52px;
-          max-width: 52px;
-          @media (min-width: @order-service-title-sm-min) {
-            max-height: 60px;
-            max-width: 60px;
-          }
-        }
-      }
-    }
-    .service-title {
-      font-size: 18px;
-      font-weight: 600;
-      line-height: 1.4;
-      @media (min-width: @order-service-title-sm-min) {
-        font-size: 22px;
-      }
-    }
-    .sub-title {
-      font-size: 20px;
-      font-weight: 600;
-      color: @color-pf-black-600;
-    }
-  }
-  .order-service-description-block {
-    margin-top: 15px;
-    .description {
-      white-space: pre-wrap;
-    }
-    .learn-more-link {
-      font-size: @font-size-small;
-      white-space: nowrap;
-    }
-  }
-  .order-service-tags {
-    margin-top: 5px;
-    .tag {
-      margin-right: 5px;
-      text-transform: uppercase;
-    }
-  }
-}
 .order-service-config {
-  flex: 0 1 auto;
   padding: 0 (@grid-gutter-width / 2);
   @media (min-width: @screen-sm-min) {
+    margin-bottom: -(@grid-gutter-width / 2);
+    margin-top: -(@grid-gutter-width / 2);
+    overflow-y: auto;
+    padding-right: @grid-gutter-width;
+    .scroll-shadows-horizontal(65%, 0.25);
     width: 50%;
+    _::-webkit-full-page-media, _:future, :root & { // only target Safari
+      .scroll-shadows-horizontal-with-covers(65%, 0.25);
+    }
     .form-horizontal .control-label {
       padding-right: 0;
     }
-  } 
+  }
   h3 {
     line-height: 1.4;
     margin-top: 0;
     + .alert {
       margin-top: 20px;
     }
-  }  
+  }
   .select-plans {
     .plan-name {
       display: inline-block;
@@ -90,6 +36,9 @@
     }
   }
   .config-top {
+    @media (min-width: @screen-sm-min) {
+      flex: 1 1 auto; // IE
+    }
     .adv-ops {
       height: 30%;
     }
@@ -151,6 +100,83 @@
         margin-right: 6px;
         padding: 11px;
       }
+    }
+  }
+}
+
+.order-service-details {
+  padding: 0 (@grid-gutter-width / 2);
+  @media (min-width: @screen-sm-min) {
+    border-right: 1px solid @color-pf-black-400;
+    overflow: hidden;
+    padding-bottom: (@grid-gutter-width / 2);
+    padding-top: (@grid-gutter-width / 2);
+    width: 50%;
+  }
+  .order-service-details-top {
+    align-items: center;
+    display: flex;
+    .service-icon {
+      margin-right: 15px;
+      .icon {
+        font-size: 60px;
+        @media (min-width: @order-service-title-sm-min) {
+          font-size: 64px;
+        }
+      }
+      .image {
+        img {
+          max-height: 52px;
+          max-width: 52px;
+          @media (min-width: @order-service-title-sm-min) {
+            max-height: 60px;
+            max-width: 60px;
+          }
+        }
+      }
+    }
+    .service-title {
+      font-size: 18px;
+      font-weight: 600;
+      line-height: 1.4;
+      @media (min-width: @order-service-title-sm-min) {
+        font-size: 22px;
+      }
+    }
+    .sub-title {
+      font-size: 20px;
+      font-weight: 600;
+      color: @color-pf-black-600;
+    }
+  }
+  .order-service-description-block {
+    margin-top: 15px;
+    .description {
+      white-space: pre-wrap;
+    }
+    .learn-more-link {
+      font-size: @font-size-small;
+      white-space: nowrap;
+    }
+  }
+  .order-service-tags {
+    margin-top: 5px;
+    .tag {
+      margin-right: 5px;
+      text-transform: uppercase;
+    }
+  }
+}
+
+.wizard-pf-contents {
+  @media (min-width: @screen-sm-min) {
+    display: flex;
+    min-height: 100%;
+    padding-bottom: (@grid-gutter-width / 2);
+    padding-top: (@grid-gutter-width / 2);
+    .scroll-shadows-horizontal-covers();
+    _::-webkit-full-page-media, _:future, :root & { // only target Safari
+      background: none;
     }
   }
 }

--- a/dist/less/overlay-panel.less
+++ b/dist/less/overlay-panel.less
@@ -40,29 +40,34 @@ body.overlay-open {
   }
 
   .wizard-pf-main {
-    background-attachment: scroll;
-    background-image: radial-gradient(ellipse at top, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0) 75%), radial-gradient(ellipse at bottom, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0) 75%);
-    background-position: 0 0, 0 100%;
-    background-repeat: no-repeat;
-    background-size: 100% 6px;
-    height: auto;
     margin-left: 0; // no sidebar
     padding: 0;
+
+    @media(max-width: @screen-xs-max) {
+      max-height: calc(100vh ~"-" (@navbar-pf-height + (@wizard-pf-steps-indicator-margin-top-bottom * 2) + @wizard-pf-steps-indicator-height + @wizard-pf-footer-height + (@grid-gutter-width / 2)));
+      .scroll-shadows-horizontal();
+    }
+
+    @media(min-width: @screen-sm-min) {
+      display: flex; // IE/Edge
+    }
   }
 
   .wizard-pf-main-inner-shadow-covers {
-    background-attachment: local;
-    background-image: linear-gradient(@color-pf-white 30%, rgba(255,255,255,0)), linear-gradient(rgba(255,255,255,0), @color-pf-white 70%);
-    background-position: 0 0, 0 100%;
-    background-repeat: no-repeat;
-    background-size: 100% 12px;
-    max-height: calc(100vh ~"-" (@navbar-pf-height + (@wizard-pf-steps-indicator-margin-top-bottom * 2) + @wizard-pf-steps-indicator-height + @wizard-pf-footer-height + (@grid-gutter-width / 2)));
-    min-height: 300px;
-    overflow-y: auto;
     padding: (@grid-gutter-width / 2);
+
+    @media(max-width: @screen-xs-max) {
+      overflow-y: auto;
+      .scroll-shadows-horizontal-covers();
+    }
 
     @media(min-width: @screen-sm-min) {
       display: flex;
+      flex: 1 1 auto;
+      max-height: calc(100vh ~"-" (@navbar-pf-height + (@wizard-pf-steps-indicator-margin-top-bottom * 2) + @wizard-pf-steps-indicator-height + @wizard-pf-footer-height + @grid-gutter-width));
+      min-height: 300px;
+      overflow: hidden;
+      padding-right: 0;
     }
 
     // so that input and textarea form-controls don't mask the inner scroll shadows

--- a/dist/origin-web-catalogs.css
+++ b/dist/origin-web-catalogs.css
@@ -181,13 +181,122 @@
     width: 475px;
   }
 }
+.order-service-config {
+  padding: 0 20px;
+}
+@media (min-width: 768px) {
+  .order-service-config {
+    margin-bottom: -20px;
+    margin-top: -20px;
+    overflow-y: auto;
+    padding-right: 40px;
+    background-attachment: scroll;
+    background-image: radial-gradient(ellipse at top, rgba(0, 0, 0, 0.25) 0%, rgba(0, 0, 0, 0) 65%), radial-gradient(ellipse at bottom, rgba(0, 0, 0, 0.25) 0%, rgba(0, 0, 0, 0) 65%);
+    background-position: 0 0, 0 100%;
+    background-repeat: no-repeat;
+    background-size: 100% 6px;
+    width: 50%;
+  }
+  .order-service-config _::-webkit-full-page-media,
+  .order-service-config _:future,
+  :root .order-service-config {
+    background-attachment: local, local, scroll, scroll;
+    background-image: linear-gradient(#ffffff 30%, rgba(255, 255, 255, 0)), linear-gradient(rgba(255, 255, 255, 0), #ffffff 70%), radial-gradient(ellipse at top, rgba(0, 0, 0, 0.25) 0%, rgba(0, 0, 0, 0) 65%), radial-gradient(ellipse at bottom, rgba(0, 0, 0, 0.25) 0%, rgba(0, 0, 0, 0) 65%);
+    background-position: 0 0, 0 100%;
+    background-repeat: no-repeat;
+    background-size: 100% 12px, 100% 12px, 100% 6px, 100% 6px;
+  }
+  .order-service-config .form-horizontal .control-label {
+    padding-right: 0;
+  }
+}
+.order-service-config h3 {
+  line-height: 1.4;
+  margin-top: 0;
+}
+.order-service-config h3 + .alert {
+  margin-top: 20px;
+}
+.order-service-config .select-plans .plan-name {
+  display: inline-block;
+  font-size: 14px;
+  margin-bottom: 5px;
+  margin-top: -2px;
+}
+.order-service-config .select-plans .radio {
+  margin-top: 15px;
+}
+@media (min-width: 768px) {
+  .order-service-config .config-top {
+    flex: 1 1 auto;
+  }
+}
+.order-service-config .config-top .adv-ops {
+  height: 30%;
+}
+.order-service-config .config-top .adv-ops-href {
+  cursor: pointer;
+  font-size: 14px;
+}
+.order-service-config .config-top .adv-ops-href::after {
+  content: '\F105';
+  font-family: 'FontAwesome';
+  padding-left: 10px;
+}
+.order-service-config .config-top .adv-ops-href.collapsed::after {
+  content: '\F107';
+}
+.order-service-config .config-top .adv-ops-container {
+  padding-top: 2px;
+}
+.order-service-config .config-bottom {
+  height: 12%;
+  float: right;
+  margin-right: -13px;
+  margin-top: 8px;
+  margin-right: -10px;
+}
+.order-service-config .footer-panel {
+  text-align: center;
+}
+.order-service-config .footer-panel a {
+  color: #fff;
+}
+.order-service-config .footer-panel a:hover {
+  color: #fff;
+  text-decoration: none;
+}
+.order-service-config .success-check {
+  color: #3f9c35;
+}
+.order-service-config .related-services-container {
+  background-color: #ededed;
+  margin-top: 62px;
+  padding: 14px;
+  display: flex;
+  align-items: center;
+}
+.order-service-config .related-services-container .related-services-label {
+  font-size: 14px;
+  font-weight: 600;
+  padding-right: 14px;
+}
+.order-service-config .related-services-container .related-services-row .card {
+  background-color: #fff;
+  border: 1px solid #bbb;
+  float: right;
+  margin-right: 6px;
+  padding: 11px;
+}
 .order-service-details {
-  flex: 0 1 auto;
   padding: 0 20px;
 }
 @media (min-width: 768px) {
   .order-service-details {
     border-right: 1px solid #bbb;
+    overflow: hidden;
+    padding-bottom: 20px;
+    padding-top: 20px;
     width: 50%;
   }
 }
@@ -248,90 +357,23 @@
   margin-right: 5px;
   text-transform: uppercase;
 }
-.order-service-config {
-  flex: 0 1 auto;
-  padding: 0 20px;
-}
 @media (min-width: 768px) {
-  .order-service-config {
-    width: 50%;
+  .wizard-pf-contents {
+    display: flex;
+    min-height: 100%;
+    padding-bottom: 20px;
+    padding-top: 20px;
+    background-attachment: local;
+    background-image: linear-gradient(#ffffff 30%, rgba(255, 255, 255, 0)), linear-gradient(rgba(255, 255, 255, 0), #ffffff 70%);
+    background-position: 0 0, 0 100%;
+    background-repeat: no-repeat;
+    background-size: 100% 12px;
   }
-  .order-service-config .form-horizontal .control-label {
-    padding-right: 0;
+  .wizard-pf-contents _::-webkit-full-page-media,
+  .wizard-pf-contents _:future,
+  :root .wizard-pf-contents {
+    background: none;
   }
-}
-.order-service-config h3 {
-  line-height: 1.4;
-  margin-top: 0;
-}
-.order-service-config h3 + .alert {
-  margin-top: 20px;
-}
-.order-service-config .select-plans .plan-name {
-  display: inline-block;
-  font-size: 14px;
-  margin-bottom: 5px;
-  margin-top: -2px;
-}
-.order-service-config .select-plans .radio {
-  margin-top: 15px;
-}
-.order-service-config .config-top .adv-ops {
-  height: 30%;
-}
-.order-service-config .config-top .adv-ops-href {
-  cursor: pointer;
-  font-size: 14px;
-}
-.order-service-config .config-top .adv-ops-href::after {
-  content: '\F105';
-  font-family: 'FontAwesome';
-  padding-left: 10px;
-}
-.order-service-config .config-top .adv-ops-href.collapsed::after {
-  content: '\F107';
-}
-.order-service-config .config-top .adv-ops-container {
-  padding-top: 2px;
-}
-.order-service-config .config-bottom {
-  height: 12%;
-  float: right;
-  margin-right: -13px;
-  margin-top: 8px;
-  margin-right: -10px;
-}
-.order-service-config .footer-panel {
-  text-align: center;
-}
-.order-service-config .footer-panel a {
-  color: #fff;
-}
-.order-service-config .footer-panel a:hover {
-  color: #fff;
-  text-decoration: none;
-}
-.order-service-config .success-check {
-  color: #3f9c35;
-}
-.order-service-config .related-services-container {
-  background-color: #ededed;
-  margin-top: 62px;
-  padding: 14px;
-  display: flex;
-  align-items: center;
-}
-.order-service-config .related-services-container .related-services-label {
-  font-size: 14px;
-  font-weight: 600;
-  padding-right: 14px;
-}
-.order-service-config .related-services-container .related-services-row .card {
-  background-color: #fff;
-  border: 1px solid #bbb;
-  float: right;
-  margin-right: 6px;
-  padding: 11px;
 }
 body.overlay-open,
 body.overlay-open .landing,
@@ -366,29 +408,45 @@ body.overlay-open .landing-side-bar {
   padding-right: 40px;
 }
 .catalogs-overlay-panel .wizard-pf-main {
-  background-attachment: scroll;
-  background-image: radial-gradient(ellipse at top, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0) 75%), radial-gradient(ellipse at bottom, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0) 75%);
-  background-position: 0 0, 0 100%;
-  background-repeat: no-repeat;
-  background-size: 100% 6px;
-  height: auto;
   margin-left: 0;
   padding: 0;
 }
+@media (max-width: 767px) {
+  .catalogs-overlay-panel .wizard-pf-main {
+    max-height: calc(100vh - 248px);
+    background-attachment: scroll;
+    background-image: radial-gradient(ellipse at top, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0) 75%), radial-gradient(ellipse at bottom, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0) 75%);
+    background-position: 0 0, 0 100%;
+    background-repeat: no-repeat;
+    background-size: 100% 6px;
+  }
+}
+@media (min-width: 768px) {
+  .catalogs-overlay-panel .wizard-pf-main {
+    display: flex;
+  }
+}
 .catalogs-overlay-panel .wizard-pf-main-inner-shadow-covers {
-  background-attachment: local;
-  background-image: linear-gradient(#fff 30%, rgba(255, 255, 255, 0)), linear-gradient(rgba(255, 255, 255, 0), #fff 70%);
-  background-position: 0 0, 0 100%;
-  background-repeat: no-repeat;
-  background-size: 100% 12px;
-  max-height: calc(100vh - 248px);
-  min-height: 300px;
-  overflow-y: auto;
   padding: 20px;
+}
+@media (max-width: 767px) {
+  .catalogs-overlay-panel .wizard-pf-main-inner-shadow-covers {
+    overflow-y: auto;
+    background-attachment: local;
+    background-image: linear-gradient(#ffffff 30%, rgba(255, 255, 255, 0)), linear-gradient(rgba(255, 255, 255, 0), #ffffff 70%);
+    background-position: 0 0, 0 100%;
+    background-repeat: no-repeat;
+    background-size: 100% 12px;
+  }
 }
 @media (min-width: 768px) {
   .catalogs-overlay-panel .wizard-pf-main-inner-shadow-covers {
     display: flex;
+    flex: 1 1 auto;
+    max-height: calc(100vh - 268px);
+    min-height: 300px;
+    overflow: hidden;
+    padding-right: 0;
   }
 }
 .catalogs-overlay-panel .wizard-pf-main-inner-shadow-covers input.form-control,

--- a/src/styles/catalog.less
+++ b/src/styles/catalog.less
@@ -2,6 +2,7 @@
 
 @import './animations.less';
 @import './landing-page.less';
+@import './mixins.less';
 @import './order-service.less';
 @import './overlay-panel.less';
 @import './projects-summary';

--- a/src/styles/mixins.less
+++ b/src/styles/mixins.less
@@ -1,0 +1,25 @@
+.scroll-shadows-horizontal(@shadow-width: 75%, @shadow-opacity: 0.2) {
+  background-attachment: scroll;
+  background-image: radial-gradient(ellipse at top, rgba(0, 0, 0, @shadow-opacity) 0%, rgba(0, 0, 0, 0) @shadow-width), radial-gradient(ellipse at bottom, rgba(0, 0, 0, @shadow-opacity) 0%, rgba(0, 0, 0, 0) @shadow-width);
+  background-position: 0 0, 0 100%;
+  background-repeat: no-repeat;
+  background-size: 100% 6px;
+}
+
+.scroll-shadows-horizontal-covers(@shadow-cover-bg-color: rgba(255,255,255,1), @shadow-cover-bg-color-transparent: rgba(255,255,255,0)) {
+  background-attachment: local;
+  background-image: linear-gradient(@shadow-cover-bg-color 30%, @shadow-cover-bg-color-transparent), linear-gradient(@shadow-cover-bg-color-transparent, @shadow-cover-bg-color 70%);
+  background-position: 0 0, 0 100%;
+  background-repeat: no-repeat;
+  background-size: 100% 12px;
+}
+
+.scroll-shadows-horizontal-with-covers(@shadow-width: 75%, @shadow-opacity: 0.2, @shadow-cover-bg-color: rgba(255,255,255,1), @shadow-cover-bg-color-transparent: rgba(255,255,255,0)) {
+  background-attachment: local, local, scroll, scroll;
+  background-image:
+    linear-gradient(@shadow-cover-bg-color 30%, @shadow-cover-bg-color-transparent), linear-gradient(@shadow-cover-bg-color-transparent, @shadow-cover-bg-color 70%),
+    radial-gradient(ellipse at top, rgba(0, 0, 0, @shadow-opacity) 0%, rgba(0, 0, 0, 0) @shadow-width), radial-gradient(ellipse at bottom, rgba(0, 0, 0, @shadow-opacity) 0%, rgba(0, 0, 0, 0) @shadow-width);
+  background-position: 0 0, 0 100%;
+  background-repeat: no-repeat;
+  background-size: 100% 12px, 100% 12px, 100% 6px, 100% 6px;
+}

--- a/src/styles/order-service.less
+++ b/src/styles/order-service.less
@@ -1,83 +1,29 @@
 // Breakpoint for showing a smaller icon and service title.
 @order-service-title-sm-min: 450px;
 
-.order-service-details {
-  flex: 0 1 auto;
-  padding: 0 (@grid-gutter-width / 2);
-  @media (min-width: @screen-sm-min) {
-    border-right: 1px solid @color-pf-black-400;
-    width: 50%;
-  }
-  .order-service-details-top {
-    align-items: center;
-    display: flex;
-    .service-icon {
-      margin-right: 15px;
-      .icon {
-        font-size: 60px;
-        @media (min-width: @order-service-title-sm-min) {
-          font-size: 64px;
-        }
-      }
-      .image {
-        img {
-          max-height: 52px;
-          max-width: 52px;
-          @media (min-width: @order-service-title-sm-min) {
-            max-height: 60px;
-            max-width: 60px;
-          }
-        }
-      }
-    }
-    .service-title {
-      font-size: 18px;
-      font-weight: 600;
-      line-height: 1.4;
-      @media (min-width: @order-service-title-sm-min) {
-        font-size: 22px;
-      }
-    }
-    .sub-title {
-      font-size: 20px;
-      font-weight: 600;
-      color: @color-pf-black-600;
-    }
-  }
-  .order-service-description-block {
-    margin-top: 15px;
-    .description {
-      white-space: pre-wrap;
-    }
-    .learn-more-link {
-      font-size: @font-size-small;
-      white-space: nowrap;
-    }
-  }
-  .order-service-tags {
-    margin-top: 5px;
-    .tag {
-      margin-right: 5px;
-      text-transform: uppercase;
-    }
-  }
-}
 .order-service-config {
-  flex: 0 1 auto;
   padding: 0 (@grid-gutter-width / 2);
   @media (min-width: @screen-sm-min) {
+    margin-bottom: -(@grid-gutter-width / 2);
+    margin-top: -(@grid-gutter-width / 2);
+    overflow-y: auto;
+    padding-right: @grid-gutter-width;
+    .scroll-shadows-horizontal(65%, 0.25);
     width: 50%;
+    _::-webkit-full-page-media, _:future, :root & { // only target Safari
+      .scroll-shadows-horizontal-with-covers(65%, 0.25);
+    }
     .form-horizontal .control-label {
       padding-right: 0;
     }
-  } 
+  }
   h3 {
     line-height: 1.4;
     margin-top: 0;
     + .alert {
       margin-top: 20px;
     }
-  }  
+  }
   .select-plans {
     .plan-name {
       display: inline-block;
@@ -90,6 +36,9 @@
     }
   }
   .config-top {
+    @media (min-width: @screen-sm-min) {
+      flex: 1 1 auto; // IE
+    }
     .adv-ops {
       height: 30%;
     }
@@ -151,6 +100,83 @@
         margin-right: 6px;
         padding: 11px;
       }
+    }
+  }
+}
+
+.order-service-details {
+  padding: 0 (@grid-gutter-width / 2);
+  @media (min-width: @screen-sm-min) {
+    border-right: 1px solid @color-pf-black-400;
+    overflow: hidden;
+    padding-bottom: (@grid-gutter-width / 2);
+    padding-top: (@grid-gutter-width / 2);
+    width: 50%;
+  }
+  .order-service-details-top {
+    align-items: center;
+    display: flex;
+    .service-icon {
+      margin-right: 15px;
+      .icon {
+        font-size: 60px;
+        @media (min-width: @order-service-title-sm-min) {
+          font-size: 64px;
+        }
+      }
+      .image {
+        img {
+          max-height: 52px;
+          max-width: 52px;
+          @media (min-width: @order-service-title-sm-min) {
+            max-height: 60px;
+            max-width: 60px;
+          }
+        }
+      }
+    }
+    .service-title {
+      font-size: 18px;
+      font-weight: 600;
+      line-height: 1.4;
+      @media (min-width: @order-service-title-sm-min) {
+        font-size: 22px;
+      }
+    }
+    .sub-title {
+      font-size: 20px;
+      font-weight: 600;
+      color: @color-pf-black-600;
+    }
+  }
+  .order-service-description-block {
+    margin-top: 15px;
+    .description {
+      white-space: pre-wrap;
+    }
+    .learn-more-link {
+      font-size: @font-size-small;
+      white-space: nowrap;
+    }
+  }
+  .order-service-tags {
+    margin-top: 5px;
+    .tag {
+      margin-right: 5px;
+      text-transform: uppercase;
+    }
+  }
+}
+
+.wizard-pf-contents {
+  @media (min-width: @screen-sm-min) {
+    display: flex;
+    min-height: 100%;
+    padding-bottom: (@grid-gutter-width / 2);
+    padding-top: (@grid-gutter-width / 2);
+    .scroll-shadows-horizontal-covers();
+    _::-webkit-full-page-media, _:future, :root & { // only target Safari
+      background: none;
     }
   }
 }

--- a/src/styles/overlay-panel.less
+++ b/src/styles/overlay-panel.less
@@ -40,29 +40,34 @@ body.overlay-open {
   }
 
   .wizard-pf-main {
-    background-attachment: scroll;
-    background-image: radial-gradient(ellipse at top, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0) 75%), radial-gradient(ellipse at bottom, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0) 75%);
-    background-position: 0 0, 0 100%;
-    background-repeat: no-repeat;
-    background-size: 100% 6px;
-    height: auto;
     margin-left: 0; // no sidebar
     padding: 0;
+
+    @media(max-width: @screen-xs-max) {
+      max-height: calc(100vh ~"-" (@navbar-pf-height + (@wizard-pf-steps-indicator-margin-top-bottom * 2) + @wizard-pf-steps-indicator-height + @wizard-pf-footer-height + (@grid-gutter-width / 2)));
+      .scroll-shadows-horizontal();
+    }
+
+    @media(min-width: @screen-sm-min) {
+      display: flex; // IE/Edge
+    }
   }
 
   .wizard-pf-main-inner-shadow-covers {
-    background-attachment: local;
-    background-image: linear-gradient(@color-pf-white 30%, rgba(255,255,255,0)), linear-gradient(rgba(255,255,255,0), @color-pf-white 70%);
-    background-position: 0 0, 0 100%;
-    background-repeat: no-repeat;
-    background-size: 100% 12px;
-    max-height: calc(100vh ~"-" (@navbar-pf-height + (@wizard-pf-steps-indicator-margin-top-bottom * 2) + @wizard-pf-steps-indicator-height + @wizard-pf-footer-height + (@grid-gutter-width / 2)));
-    min-height: 300px;
-    overflow-y: auto;
     padding: (@grid-gutter-width / 2);
+
+    @media(max-width: @screen-xs-max) {
+      overflow-y: auto;
+      .scroll-shadows-horizontal-covers();
+    }
 
     @media(min-width: @screen-sm-min) {
       display: flex;
+      flex: 1 1 auto;
+      max-height: calc(100vh ~"-" (@navbar-pf-height + (@wizard-pf-steps-indicator-margin-top-bottom * 2) + @wizard-pf-steps-indicator-height + @wizard-pf-footer-height + @grid-gutter-width));
+      min-height: 300px;
+      overflow: hidden;
+      padding-right: 0;
     }
 
     // so that input and textarea form-controls don't mask the inner scroll shadows


### PR DESCRIPTION
Fixes #196 

At a tall, wide desktop resolution, very long descriptions clip if they exceed the max-height of the panel
<img width="1239" alt="screen shot 2017-05-09 at 4 51 04 pm" src="https://cloud.githubusercontent.com/assets/895728/25872252/fc682224-34d7-11e7-83db-4e6b12d09f8b.PNG">

At short, wide desktop resolution, very long descriptions clip and the right side panel scrolls if the contents are taller than the panel
<img width="1236" alt="screen shot 2017-05-09 at 4 51 17 pm" src="https://cloud.githubusercontent.com/assets/895728/25872280/153ebbf0-34d8-11e7-8667-1f374e03a819.PNG">
<img width="1230" alt="screen shot 2017-05-09 at 4 51 27 pm" src="https://cloud.githubusercontent.com/assets/895728/25872281/1542880c-34d8-11e7-9e64-ff791c7cc3d2.PNG">

At mobile, there is no change in the behavior and the two columns collapse to one and there is an inner scroll
![screen shot 2017-05-05 at 1 56 06 pm](https://cloud.githubusercontent.com/assets/895728/25758152/5b517244-319b-11e7-875a-ae59407695a7.PNG)

Whatchyall think?  @jwforres, @spadgett, @sg00dwin, @serenamarie125, @beanh66, etc.


