### PR TITLE
Remember selected-project when going between steps of Ordering Panel

### DIFF
--- a/dist/origin-web-catalogs.js
+++ b/dist/origin-web-catalogs.js
@@ -971,8 +971,8 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             this.ctrl.iconClass = this.ctrl.serviceClass.iconClass || "fa fa-cubes", this.ctrl.imageUrl = this.ctrl.serviceClass.imageUrl, 
             this.ctrl.serviceName = this.ctrl.serviceClass.name, this.ctrl.description = this.ctrl.serviceClass.description, 
             this.ctrl.longDescription = this.ctrl.serviceClass.longDescription, this.ctrl.plans = a.get(this, "ctrl.serviceClass.resource.plans", []), 
-            this.ctrl.forms = {}, this.ctrl.selectedPlan = a.first(this.ctrl.plans), this.ctrl.selectedProject = {}, 
-            this.ctrl.planIndex = 0, this.ctrl.steps = [ {
+            this.ctrl.forms = {}, this.ctrl.selectedPlan = a.first(this.ctrl.plans), this.ctrl.planIndex = 0, 
+            this.ctrl.steps = [ {
                 id: "plans",
                 label: "Plans",
                 view: "order-service/order-service-plans.html"
@@ -1233,7 +1233,8 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
                     }
                 };
                 e.ctrl.projects = r.sortBy(t.by("metadata.name"), e.$filter("displayName")), e.ctrl.existingProjectNames = r.map(e.ctrl.projects, "metadata.name"), 
-                e.ctrl.selectedProject = e.$filter("mostRecent")(e.ctrl.projects), e.ctrl.canCreate && e.ctrl.projects.unshift(n);
+                e.ctrl.selectedProject || (e.ctrl.selectedProject = e.$filter("mostRecent")(e.ctrl.projects)), 
+                e.ctrl.canCreate && e.ctrl.projects.unshift(n);
             });
         }, e;
     }();

--- a/src/components/order-service/order-service.controller.ts
+++ b/src/components/order-service/order-service.controller.ts
@@ -32,7 +32,6 @@ export class OrderServiceController implements angular.IController {
 
     // Preselect the first plan. If there's only one plan, skip the wizard step.
     this.ctrl.selectedPlan = _.first(this.ctrl.plans);
-    this.ctrl.selectedProject = {};
     this.ctrl.planIndex = 0;
     this.ctrl.steps = [{
       id: 'plans',

--- a/src/components/select-project/select-project.controller.ts
+++ b/src/components/select-project/select-project.controller.ts
@@ -73,7 +73,9 @@ export class SelectProjectController implements angular.IController {
       this.ctrl.existingProjectNames = _.map(this.ctrl.projects, 'metadata.name');
 
       // get most recently created
-      this.ctrl.selectedProject = this.$filter('mostRecent')(this.ctrl.projects);
+      if (!this.ctrl.selectedProject) {
+        this.ctrl.selectedProject = this.$filter('mostRecent')(this.ctrl.projects);
+      }
 
       if (this.ctrl.canCreate) {
         this.ctrl.projects.unshift(createProject);

--- a/src/services/catalog.service.ts
+++ b/src/services/catalog.service.ts
@@ -245,7 +245,7 @@ export class CatalogService {
     deferred.resolve([results, errorMsg]);
   }
 
-  private formatArray(arr){
+  private formatArray(arr: string[]) {
     var outStr = "";
     if (arr.length === 1) {
       outStr = arr[0];

--- a/test/select-project.spec.ts
+++ b/test/select-project.spec.ts
@@ -41,7 +41,7 @@ describe('Select Project Component', () => {
   });
 
   var createSelectProjectDropdown = function() {
-    selectedProject = {};
+    selectedProject = null;
     nameTaken = false;
     var selectProjectHtml: string = '<select-project selected-project="selectedProject" name-taken="nameTaken"></select-project>';
     componentTest = new ComponentTest<SelectProjectController>(selectProjectHtml);


### PR DESCRIPTION
Hi,
This fixes https://bugzilla.redhat.com/show_bug.cgi?id=1449268
Also tested that the 'create-project' form fields are persisted between wizard steps as well.