### PR TITLE
Fixing bug where wizard steps indicator was too narrow in IE11

### DIFF
--- a/dist/less/overlay-panel.less
+++ b/dist/less/overlay-panel.less
@@ -80,6 +80,7 @@ body.overlay-open {
   }
 
   .wizard-pf-steps-indicator {
+    display: flex; // PatternFly doesn't set this for IE
     height: @wizard-pf-steps-indicator-height;
     margin: @wizard-pf-steps-indicator-margin-top-bottom 0;
     padding: 0;

--- a/dist/origin-web-catalogs.css
+++ b/dist/origin-web-catalogs.css
@@ -402,6 +402,7 @@ body.overlay-open .landing-side-bar {
   background-color: rgba(234, 234, 234, 0.5);
 }
 .catalogs-overlay-panel .wizard-pf-steps-indicator {
+  display: flex;
   height: 52px;
   margin: 30px 0;
   padding: 0;

--- a/src/styles/overlay-panel.less
+++ b/src/styles/overlay-panel.less
@@ -80,6 +80,7 @@ body.overlay-open {
   }
 
   .wizard-pf-steps-indicator {
+    display: flex; // PatternFly doesn't set this for IE
     height: @wizard-pf-steps-indicator-height;
     margin: @wizard-pf-steps-indicator-margin-top-bottom 0;
     padding: 0;


### PR DESCRIPTION
Before:

![screen shot 2017-05-11 at 4 40 55 pm](https://cloud.githubusercontent.com/assets/895728/25971059/f6371620-3668-11e7-8a7b-f552d7cb5e34.PNG)

After:

![screen shot 2017-05-11 at 4 28 31 pm](https://cloud.githubusercontent.com/assets/895728/25971066/fa5bd13c-3668-11e7-84c8-c6ff83e90ed7.PNG)
