### PR TITLE
Adjust max-height and remove max-width to allow img size to remain proportional in Firefox

### DIFF
--- a/dist/less/projects-summary.less
+++ b/dist/less/projects-summary.less
@@ -122,8 +122,7 @@
           width: 60px;
         }
         img {
-          max-height: 30%;
-          max-width: 30%;
+          max-height: 17px;
         }
       }
       .services-item-name {

--- a/dist/less/services-view.less
+++ b/dist/less/services-view.less
@@ -87,8 +87,7 @@
     position: relative;
 
     img {
-      max-height: 50px;
-      max-width: 50px;
+      max-height: 26px;
     }
   }
 

--- a/dist/origin-web-catalogs.css
+++ b/dist/origin-web-catalogs.css
@@ -562,8 +562,7 @@ body.overlay-open .landing-side-bar {
   width: 60px;
 }
 .catalog-projects-summary-panel .services-view .services-item .services-item-icon img {
-  max-height: 30%;
-  max-width: 30%;
+  max-height: 17px;
 }
 .catalog-projects-summary-panel .services-view .services-item .services-item-name {
   color: #fff;
@@ -947,8 +946,7 @@ body.overlay-open .landing-side-bar {
   position: relative;
 }
 .services-view .services-item-icon img {
-  max-height: 50px;
-  max-width: 50px;
+  max-height: 26px;
 }
 .services-view .services-item-name {
   flex: 1 1 0%;

--- a/src/styles/projects-summary.less
+++ b/src/styles/projects-summary.less
@@ -122,8 +122,7 @@
           width: 60px;
         }
         img {
-          max-height: 30%;
-          max-width: 30%;
+          max-height: 17px;
         }
       }
       .services-item-name {

--- a/src/styles/services-view.less
+++ b/src/styles/services-view.less
@@ -87,8 +87,7 @@
     position: relative;
 
     img {
-      max-height: 50px;
-      max-width: 50px;
+      max-height: 26px;
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/openshift/origin-web-catalog/issues/210

Attempt at setting the optimal max-height for the majority of logos sizes that are 1 to 1 and up to 2.5 to 1 width to height dimension ratios

AWS logo native dimensions are 768x280
removed max-width causing distorted sizing in Firefox



<img width="641" alt="screen shot 2017-05-11 at 4 36 27 pm" src="https://cloud.githubusercontent.com/assets/1874151/25971617/e766c2e2-366a-11e7-8524-1a22d0ef1847.png">
<img width="422" alt="screen shot 2017-05-11 at 4 34 26 pm" src="https://cloud.githubusercontent.com/assets/1874151/25971616/e7660fa0-366a-11e7-9193-949f26e47d05.png">
