### PR TITLE
Avoid button flicker in provision service dialog

### DIFF
--- a/dist/origin-web-catalogs.js
+++ b/dist/origin-web-catalogs.js
@@ -1159,7 +1159,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
                 onShow: this.showResults
             }, this.ctrl.steps = [ this.planStep, this.configStep, this.bindStep, this.reviewStep ], 
             this.ctrl.nameTaken = !1, this.ctrl.wizardReady = !0, this.ctrl.wizardDone = !1, 
-            this.ctrl.updating = !1, this.selectedProjectWatch = this.$scope.$watch(function() {
+            this.ctrl.updating = !0, this.selectedProjectWatch = this.$scope.$watch(function() {
                 return e.ctrl.selectedProject;
             }, this.onProjectUpdate);
             var t = this.$filter("humanizeKind");

--- a/src/components/order-service/order-service.controller.ts
+++ b/src/components/order-service/order-service.controller.ts
@@ -98,8 +98,11 @@ export class OrderServiceController implements angular.IController {
     this.ctrl.nameTaken = false;
     this.ctrl.wizardReady = true;
     this.ctrl.wizardDone = false;
-    this.ctrl.updating = false;
 
+    // Set updating true initially so that the next button doesn't enable,
+    // disable, then enable again immediately.  The onProjectUpdate callback
+    // will set this back to false.
+    this.ctrl.updating = true;
     this.selectedProjectWatch = this.$scope.$watch(
       () => {
         return this.ctrl.selectedProject;


### PR DESCRIPTION
Prevent some button flicker when the provision service overlay is first displayed by setting it to `updating` initially.