### PR TITLE
Fixes bug in console where category/subcategory arrows are misaligned

### DIFF
--- a/dist/less/services-view.less
+++ b/dist/less/services-view.less
@@ -423,6 +423,7 @@ services-view,
           background-color: fade(@color-pf-blue-700, 90%);
           float: none;
           margin-bottom: 1px;
+          padding-right: 0; // fixes bug in console where arrows are misaligned
           position: relative;
 
           &.active {

--- a/dist/origin-web-catalogs.css
+++ b/dist/origin-web-catalogs.css
@@ -1407,6 +1407,7 @@ services-view,
     background-color: rgba(0, 34, 53, 0.9);
     float: none;
     margin-bottom: 1px;
+    padding-right: 0;
     position: relative;
   }
   .services-view .services-view-container .services-categories > li.active > a,

--- a/src/styles/services-view.less
+++ b/src/styles/services-view.less
@@ -423,6 +423,7 @@ services-view,
           background-color: fade(@color-pf-blue-700, 90%);
           float: none;
           margin-bottom: 1px;
+          padding-right: 0; // fixes bug in console where arrows are misaligned
           position: relative;
 
           &.active {


### PR DESCRIPTION
Bug as seen in console:
![screen shot 2017-06-15 at 9 52 39 am](https://user-images.githubusercontent.com/895728/27185162-7fd7b15a-51b2-11e7-88a2-76737023a040.PNG)

Console using this fix:
![screen shot 2017-06-15 at 10 08 15 am](https://user-images.githubusercontent.com/895728/27185196-957caf42-51b2-11e7-993f-8026c61750f9.PNG)
