### PR TITLE
Fixes 'Next never enables if provision service and no projects exist'

### DIFF
--- a/app/mockServices/mockData/services.ts
+++ b/app/mockServices/mockData/services.ts
@@ -15,6 +15,7 @@ export const servicesData = {
     plans: [
       {
         name: 'rh-ded-topic', osbGuid: '1', displayName: 'Red Hat - Dedicated - Topic', description: '$.65 / 1 Million messages', bullets: ['One', 'Two', 'Three'],
+        bindable: true,
         alphaInstanceCreateParameterSchema: {
           "$schema": "http://json-schema.org/draft-04/schema",
           "type": "object",

--- a/dist/origin-web-catalogs.js
+++ b/dist/origin-web-catalogs.js
@@ -1140,7 +1140,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
                 } else l.ctrl.projectDisplayName = l.$filter("displayName")(l.ctrl.selectedProject), 
                 l.createService();
             }, this.onProjectUpdate = function() {
-                l.isNewProject() ? (l.ctrl.applications = [], l.updateBindability()) : (l.ctrl.updating = !0, 
+                l.isNewProject() ? (l.ctrl.applications = [], l.ctrl.updating = !1, l.updateBindability()) : (l.ctrl.updating = !0, 
                 l.ProjectsService.get(l.ctrl.selectedProject.metadata.name).then(i.spread(function(e, t) {
                     l.ctrl.bindType = "none", l.ctrl.serviceToBind = l.ctrl.serviceClass, l.DataService.list("deploymentconfigs", t).then(function(e) {
                         l.deploymentConfigs = i.toArray(e.by("metadata.name")), l.sortApplications();

--- a/src/components/order-service/order-service.controller.ts
+++ b/src/components/order-service/order-service.controller.ts
@@ -317,6 +317,7 @@ export class OrderServiceController implements angular.IController {
   private onProjectUpdate = () => {
     if (this.isNewProject()) {
       this.ctrl.applications = [];
+      this.ctrl.updating = false;
       this.updateBindability();
     } else {
       this.ctrl.updating = true;


### PR DESCRIPTION
Fixes #294 

Bug only affected provisioning a service class.  Provisioning builder images uses slightly different logic and isn't effected by this bug.