### PR TITLE
Add bindable to mock service class data

### DIFF
--- a/app/mockServices/mockData/services.ts
+++ b/app/mockServices/mockData/services.ts
@@ -5,6 +5,7 @@ export const servicesData = {
       "name": "test-serviceclass-java-nodejs",
       "uid": "1",
     },
+    bindable: true,
     description: 'BUILDS SOURCE CODE',
     alphaTags: ['java', 'nodejs'],
     externalMetadata: {
@@ -67,6 +68,7 @@ export const servicesData = {
       "name": "test-serviceclass-nodejs",
       "uid": "2",
     },
+    bindable: true,
     description: 'BUILDS SOURCE CODE',
     alphaTags: ['nodejs'],
     externalMetadata: {
@@ -83,6 +85,7 @@ export const servicesData = {
       "name": "test-serviceclass-perl",
       "uid": "3",
     },
+    bindable: true,
     description: 'BUILDS SOURCE CODE',
     alphaTags: ['perl'],
     externalMetadata: {
@@ -99,6 +102,7 @@ export const servicesData = {
       "name": "test-serviceclass-ruby-mongo",
       "uid": "4",
     },
+    bindable: true,
     description: 'BUILDS SOURCE CODE',
     alphaTags: ['ruby', 'mongodb'],
     externalMetadata: {
@@ -115,6 +119,7 @@ export const servicesData = {
       "name": "test-serviceclass-php",
       "uid": "5",
     },
+    bindable: true,
     description: 'BUILDS SOURCE CODE',
     alphaTags: ['php'],
     externalMetadata: {
@@ -131,6 +136,7 @@ export const servicesData = {
       "name": "test-serviceclass-mongo",
       "uid": "6",
     },
+    bindable: true,
     description: 'BUILDS SOURCE CODE',
     alphaTags: ['mongodb'],
     externalMetadata: {
@@ -147,6 +153,7 @@ export const servicesData = {
       "name": "test-serviceclass-mysql",
       "uid": "7",
     },
+    bindable: true,
     description: 'BUILDS SOURCE CODE',
     alphaTags: ['mysql'],
     externalMetadata: {
@@ -163,6 +170,7 @@ export const servicesData = {
       "name": "test-serviceclass-other",
       "uid": "8",
     },
+    bindable: true,
     description: 'BUILDS SOURCE CODE',
     alphaTags: ['fooBar'],
     externalMetadata: {
@@ -180,6 +188,7 @@ export const servicesData = {
       "name": "test-serviceclass-jenkins",
       "uid": "9",
     },
+    bindable: true,
     description: 'BUILDS SOURCE CODE',
     alphaTags: ['jenkins'],
     externalMetadata: {


### PR DESCRIPTION
`bindable` is a required parameter on service class.