### PR TITLE
Remove messenger dependency from sample app

### DIFF
--- a/app/app.less
+++ b/app/app.less
@@ -1,4 +1,3 @@
-@import (css) "~messenger/build/css/messenger-theme-flat.css";
 @import (css) "~hopscotch/dist/css/hopscotch.css";
 
 @import (css) "~patternfly/dist/css/patternfly.css";

--- a/bower.json
+++ b/bower.json
@@ -62,7 +62,6 @@
     "js-yaml": "3.6.1",
     "layout.attrs": "2.1.1",
     "matchHeight": "0.7.0",
-    "messenger": "1.4.1",
     "moment": "~2.18.1",
     "moment-timezone": "0.5.3",
     "ng-sortable": "1.3.4",


### PR DESCRIPTION
Messenger was removed from common in favor of Patternfly toasts.