### PR TITLE
By default, do not auto-launch landing page tour on first access

### DIFF
--- a/dist/origin-web-catalogs.js
+++ b/dist/origin-web-catalogs.js
@@ -383,7 +383,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
         }, p = {
             landing_page_tour: {
                 enabled: !0,
-                auto_launch: !0,
+                auto_launch: !1,
                 steps: d
             }
         };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -146,7 +146,7 @@ var homePageTourSteps = {
 var guidedTours = {
   landing_page_tour: {
     enabled: true,
-    auto_launch: true,
+    auto_launch: false,
     steps: homePageTourSteps
   }
 };


### PR DESCRIPTION
Fixes #321 