### PR TITLE
Prevent applying empty keyword filter

### DIFF
--- a/dist/origin-web-catalogs.js
+++ b/dist/origin-web-catalogs.js
@@ -1515,8 +1515,8 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             }, this.previousSubCategoryHeight = 0, this.resizeRetries = 0, this.handleClick = function(e, t) {
                 p.$scope.$emit("open-overlay-panel", e);
             }, this.filterChange = function(e) {
-                p.filterByCategory(p.ctrl.currentFilter, p.ctrl.currentSubFilter, !1), p.ctrl.filterConfig.appliedFilters = e, 
-                e && e.length > 0 && i.each(e, function(e) {
+                p.filterByCategory(p.ctrl.currentFilter, p.ctrl.currentSubFilter, !1), e = i.filter(e, "value"), 
+                p.ctrl.filterConfig.appliedFilters = e, e && e.length > 0 && i.each(e, function(e) {
                     p.ctrl.filteredItems = p.filterForKeywords(e.value, p.ctrl.filteredItems);
                 }), p.updateFilterControls();
             }, this.constants = e, this.catalog = t, this.keywordService = n, this.logger = r, 

--- a/src/components/services-view/services-view.controller.ts
+++ b/src/components/services-view/services-view.controller.ts
@@ -191,6 +191,12 @@ export class ServicesViewController implements angular.IController {
   private filterChange = (filters: any) => {
     this.filterByCategory(this.ctrl.currentFilter, this.ctrl.currentSubFilter, false);
 
+    // only use filters which have a filter criteria 'value'
+    // prevents applying an empty keyword filter
+    // TODO: can remove the following line of code after angular-patternfly issue is fixed:
+    //   https://github.com/patternfly/angular-patternfly/issues/509
+    filters = _.filter(filters, 'value');
+
     this.ctrl.filterConfig.appliedFilters = filters;
 
     if (filters && filters.length > 0) {


### PR DESCRIPTION
Fixes #341 

One line change to filter out any 'filters' which do not have keyword 'values' (empty filters)

Filed a-pf Issue: patternfly/angular-patternfly#509