### PR TITLE
Use headline case consistently for placeholder text

### DIFF
--- a/dist/origin-web-catalogs.js
+++ b/dist/origin-web-catalogs.js
@@ -1510,7 +1510,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             this.ctrl = this, this.keywordFilterField = {
                 id: "keyword",
                 title: "Keyword",
-                placeholder: "Filter by keyword in Category",
+                placeholder: "Filter by Keyword in Category",
                 filterType: "text"
             }, this.previousSubCategoryHeight = 0, this.resizeRetries = 0, this.handleClick = function(e, t) {
                 p.$scope.$emit("open-overlay-panel", e);

--- a/src/components/services-view/services-view.controller.ts
+++ b/src/components/services-view/services-view.controller.ts
@@ -23,7 +23,7 @@ export class ServicesViewController implements angular.IController {
   private keywordFilterField: any = {
     id: 'keyword',
     title:  'Keyword',
-    placeholder: 'Filter by keyword in Category',
+    placeholder: 'Filter by Keyword in Category',
     filterType: 'text'
   };
   private removeFilterListener: any;


### PR DESCRIPTION
I'm assuming this placeholder text should use headline case since "Category" is capitalized. Also "Search Catalog" is headline. It looks odd to me with lowercase "keyword" and uppercase "Category."