### PR TITLE
Avoid runtime error when service class displayName set to null

### DIFF
--- a/dist/origin-web-catalogs.js
+++ b/dist/origin-web-catalogs.js
@@ -15,7 +15,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
 }, function(e, t) {
     e.exports = '<bind-service-form service-class="$ctrl.serviceClass.resource"\n                   service-class-name="$ctrl.serviceClass.name"\n                   applications="$ctrl.applications"\n                   form-name="$ctrl.forms.bindForm"\n                   allow-no-binding="true"\n                   project-name="$ctrl.projectDisplayName"\n                   bind-type="$ctrl.bindType"\n                   app-to-bind="$ctrl.appToBind">\n</bind-service-form>\n';
 }, function(e, t) {
-    e.exports = '<div class="config-top">\n  <form name="$ctrl.forms.orderConfigureForm" class="config-form">\n    <select-project selected-project="$ctrl.selectedProject" name-taken="$ctrl.nameTaken"></select-project>\n    <catalog-parameters\n      ng-if="$ctrl.parameterSchema"\n      model="$ctrl.parameterData"\n      parameter-schema="$ctrl.parameterSchema">\n    </catalog-parameters>\n  </form>\n  <div ng-if="$ctrl.error" class="has-error">\n    <span class="help-block">{{$ctrl.error}}</span>\n  </div>\n</div>\n';
+    e.exports = '<div class="config-top">\n  <form name="$ctrl.forms.orderConfigureForm" class="config-form">\n    <select-project selected-project="$ctrl.selectedProject" name-taken="$ctrl.nameTaken"></select-project>\n    <catalog-parameters\n      ng-if="$ctrl.parameterSchema.properties"\n      model="$ctrl.parameterData"\n      parameter-schema="$ctrl.parameterSchema">\n    </catalog-parameters>\n  </form>\n  <div ng-if="$ctrl.error" class="has-error">\n    <span class="help-block">{{$ctrl.error}}</span>\n  </div>\n</div>\n';
 }, function(e, t) {
     e.exports = '<div class="config-top">\n  <div class="select-plans">\n    <h3>Select a Plan</h3>\n    <div ng-repeat="plan in $ctrl.serviceClass.resource.plans" class="radio">\n      <label>\n        <input\n          type="radio"\n          ng-model="$ctrl.planIndex"\n          ng-change="$ctrl.selectPlan(plan)"\n          value="{{$index}}">\n        <span class="plan-name">{{plan.externalMetadata.displayName || plan.name}}</span>\n        \x3c!-- TODO: truncate long text --\x3e\n        <div ng-if="plan.description">{{plan.description}}</div>\n        \x3c!-- TODO: show plan bullets --\x3e\n      </label>\n    </div>\n  </div>\n</div>\n';
 }, function(e, t) {
@@ -712,18 +712,18 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             this.tags = this.getTags();
         }
         return e.prototype.getImage = function() {
-            return i.get(this.resource, "externalMetadata.imageUrl", "");
+            return i.get(this.resource, "externalMetadata.imageUrl") || "";
         }, e.prototype.getIcon = function() {
-            var e = i.get(this.resource, [ "externalMetadata", "console.openshift.io/iconClass" ], "fa fa-clone");
+            var e = i.get(this.resource, [ "externalMetadata", "console.openshift.io/iconClass" ]) || "fa fa-clone";
             return e = -1 !== e.indexOf("icon-") ? "font-icon " + e : e;
         }, e.prototype.getName = function() {
-            return i.get(this.resource, "externalMetadata.displayName", this.resource.metadata.name);
+            return i.get(this.resource, "externalMetadata.displayName") || this.resource.metadata.name;
         }, e.prototype.getDescription = function() {
-            return i.get(this.resource, "description", "");
+            return i.get(this.resource, "description") || "";
         }, e.prototype.getLongDescription = function() {
-            return i.get(this.resource, "externalMetadata.longDescription", "");
+            return i.get(this.resource, "externalMetadata.longDescription") || "";
         }, e.prototype.getTags = function() {
-            return i.get(this.resource, "alphaTags", []);
+            return i.get(this.resource, "alphaTags") || [];
         }, e;
     }();
     t.ServiceItem = a;

--- a/src/components/order-service/order-service-configure.html
+++ b/src/components/order-service/order-service-configure.html
@@ -2,7 +2,7 @@
   <form name="$ctrl.forms.orderConfigureForm" class="config-form">
     <select-project selected-project="$ctrl.selectedProject" name-taken="$ctrl.nameTaken"></select-project>
     <catalog-parameters
-      ng-if="$ctrl.parameterSchema"
+      ng-if="$ctrl.parameterSchema.properties"
       model="$ctrl.parameterData"
       parameter-schema="$ctrl.parameterSchema">
     </catalog-parameters>

--- a/src/services/catalog.service.ts
+++ b/src/services/catalog.service.ts
@@ -286,30 +286,30 @@ export class ServiceItem implements IServiceItem {
     this.tags = this.getTags();
   }
 
-  private getImage() {
-    return _.get(this.resource, 'externalMetadata.imageUrl', '');
+  private getImage(): string {
+    return _.get(this.resource, 'externalMetadata.imageUrl') as string || '';
   }
 
-  private getIcon() {
-    let icon = _.get(this.resource, ['externalMetadata', 'console.openshift.io/iconClass'], 'fa fa-clone');
+  private getIcon(): string {
+    let icon: string = _.get(this.resource, ['externalMetadata', 'console.openshift.io/iconClass']) as string || 'fa fa-clone';
     icon = (icon.indexOf('icon-') !== -1) ? 'font-icon ' + icon : icon;
     return icon;
   }
 
-  private getName() {
-    return _.get(this.resource, 'externalMetadata.displayName', this.resource.metadata.name);
+  private getName(): string {
+    return _.get(this.resource, 'externalMetadata.displayName') || this.resource.metadata.name;
   }
 
-  private getDescription() {
-    return _.get(this.resource, 'description', '');
+  private getDescription(): string {
+    return _.get(this.resource, 'description') as string || '';
   }
 
-  private getLongDescription() {
-    return _.get(this.resource, 'externalMetadata.longDescription', '');
+  private getLongDescription(): string {
+    return _.get(this.resource, 'externalMetadata.longDescription') as string || '';
   }
 
-  private getTags() {
-    return _.get(this.resource, 'alphaTags', []);
+  private getTags(): string[] {
+    return _.get(this.resource, 'alphaTags') as string[] || [];
   }
 }
 


### PR DESCRIPTION
Fix a problem where a runtime error occurs when the `displayName` for a service class is explicitly set to `null` (rather than undefined).

@dymurray 