### PR TITLE
Fixes IE11 bug where .service-items didn't properly size

### DIFF
--- a/dist/less/services-view.less
+++ b/dist/less/services-view.less
@@ -120,6 +120,7 @@ services-view,
     flex: 1 1 auto;
     flex-wrap: wrap;
     padding-bottom: 30px; // give equal space below last row of service-items
+    width: 100%; // IE11
     z-index: 9; // elevate so that toggling tiles that cause repositioning do not overlay main content block
   }
 

--- a/dist/origin-web-catalogs.css
+++ b/dist/origin-web-catalogs.css
@@ -1174,6 +1174,7 @@ services-view,
   flex: 1 1 auto;
   flex-wrap: wrap;
   padding-bottom: 30px;
+  width: 100%;
   z-index: 9;
 }
 .services-view .services-items-filter {

--- a/src/styles/services-view.less
+++ b/src/styles/services-view.less
@@ -120,6 +120,7 @@ services-view,
     flex: 1 1 auto;
     flex-wrap: wrap;
     padding-bottom: 30px; // give equal space below last row of service-items
+    width: 100%; // IE11
     z-index: 9; // elevate so that toggling tiles that cause repositioning do not overlay main content block
   }
 


### PR DESCRIPTION
Resulting in improper sizing of .service-item

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1473615
Note:  Release of origin-web-catalog and consumption of said release by origin-web-console required to fully resolve bug.

After:
![screen shot 2017-07-21 at 4 18 24 pm](https://user-images.githubusercontent.com/895728/28480773-4415822e-6e30-11e7-8659-8e7dc09763d3.PNG)
