### PR TITLE
Bump version to 0.0.34

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "origin-web-catalog",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "license": "Apache-2.0",
   "main": [
     "dist/vendor-bundle.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "origin-web-catalog",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "description": "The Openshift Web Catalogs Library",
   "scripts": {
     "clean": "rimraf dist && rimraf docs && rimraf coverage",


### PR DESCRIPTION
Bumping versions so we can update Patternfly in origin-web-console without bower overrides. Needed to pick up @jeff-phillips-18's fix for the dialog next button callback.