### PR TITLE
Read and use form definition for parameters if supplied by broker.

### DIFF
--- a/app/mockServices/mockData/services.ts
+++ b/app/mockServices/mockData/services.ts
@@ -207,5 +207,120 @@ export const servicesData = {
     plans: [
       {name: 'rh-ded-topic', osbGuid: '1', displayName: 'Red Hat - Dedicated - Topic', description: '$.65 / 1 Million messages', bullets: ['One', 'Two', 'Three']}
     ]
-  }
+  },
+  "test-serviceclass-pg-apb": {
+    kind: 'ServiceClass',
+    "metadata": {
+      "name": "test-serviceclass-pg-apb",
+      "uid": "10",
+    },
+    bindable: true,
+    description: 'TEST APB SERVICE',
+    alphaTags: ['databases', 'postgresql'],
+    externalMetadata: {
+      displayName: 'Test ServiceClass PostgreSQL DB APB',
+      longDescription: 'A sample APB which deploys a PostgreSQL Database',
+    },
+    plans: [
+      {
+        name: "default",
+        externalID: "default",
+        description: "A sample APB which deploys Hello World Database",
+        free: true,
+        externalMetadata: {
+          cost: "$0.00",
+          displayName: "Default",
+          longDescription: "This plan deploys a Postgres Database the Hello World application can connect to",
+          schemas: {
+            service_binding: {
+              create: {
+                openshift_form_definition: [
+                  "postgresql_database",
+                  {
+                    items: [
+                      "postgresql_user",
+                      {
+                        key: "postgresql_password",
+                        type: "password"
+                      }
+                    ],
+                    title: "User Information",
+                    type: "fieldset"
+                  }
+                ]
+              }
+            },
+            service_instance: {
+              create: {
+                openshift_form_definition: [
+                  "postgresql_database",
+                  {
+                    items: [
+                      "postgresql_user",
+                      {
+                        key: "postgresql_password",
+                        type: "password"
+                      }
+                    ],
+                    title: "User Information",
+                    type: "fieldset"
+                  }
+                ]
+              },
+              update: {}
+            }
+          }
+        },
+        alphaInstanceCreateParameterSchema: {
+          "$schema": "http://json-schema.org/draft-04/schema",
+          additionalProperties: false,
+          properties: {
+            postgresql_database: {
+              "default": "admin",
+              title: "PostgreSQL Database Name",
+              type: "string"
+            },
+            postgresql_password: {
+              "default": "admin",
+              title: "PostgreSQL Password",
+              type: "string"
+            },
+            postgresql_user: {
+              "default": "admin",
+              title: "PostgreSQL User",
+              type: "string"
+            }
+          },
+          required: [
+            "postgresql_database",
+            "postgresql_user",
+            "postgresql_password"
+          ],
+          type: "object"
+        },
+        alphaBindingCreateParameterSchema: {
+          "$schema": "http://json-schema.org/draft-04/schema",
+          additionalProperties: false,
+          properties: {
+            postgresql_database: {
+              "default": "admin",
+              title: "PostgreSQL Database Name",
+              type: "string"
+            },
+            postgresql_password: {
+              "default": "admin",
+              title: "PostgreSQL Password",
+              type: "string"
+            },
+            postgresql_user: {
+              "default": "admin",
+              title: "PostgreSQL User",
+              type: "string"
+            }
+          },
+          type: "object"
+        }
+      }
+    ]
+  },
 };

--- a/dist/less/order-service.less
+++ b/dist/less/order-service.less
@@ -203,4 +203,16 @@
     min-height: 200px;
     overflow-y: auto;
   }
+
+  .schema-form-fieldset {
+    margin-bottom: 40px;
+    margin-top: 40px;
+
+    legend {
+      border-bottom: none;
+      border-top: solid 1px rgba(0, 0, 0, 0.15);
+      margin-bottom: 10px;
+      padding-top: 20px;
+    }
+  }
 }

--- a/dist/origin-web-catalogs.css
+++ b/dist/origin-web-catalogs.css
@@ -466,6 +466,16 @@ landingbody,
     overflow-y: auto;
   }
 }
+.order-service-wizard-step.wizard-pf-main .schema-form-fieldset {
+  margin-bottom: 40px;
+  margin-top: 40px;
+}
+.order-service-wizard-step.wizard-pf-main .schema-form-fieldset legend {
+  border-bottom: none;
+  border-top: solid 1px rgba(0, 0, 0, 0.15);
+  margin-bottom: 10px;
+  padding-top: 20px;
+}
 body.overlay-open,
 body.overlay-open .landing,
 body.overlay-open .landing-side-bar {

--- a/dist/origin-web-catalogs.js
+++ b/dist/origin-web-catalogs.js
@@ -15,7 +15,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
 }, function(e, t) {
     e.exports = '<bind-service-form service-class="$ctrl.serviceClass.resource"\n                   service-class-name="$ctrl.serviceClass.name"\n                   applications="$ctrl.applications"\n                   form-name="$ctrl.forms.bindForm"\n                   allow-no-binding="true"\n                   project-name="$ctrl.projectDisplayName"\n                   bind-type="$ctrl.bindType"\n                   app-to-bind="$ctrl.appToBind">\n</bind-service-form>\n';
 }, function(e, t) {
-    e.exports = '<div class="config-top">\n  <form name="$ctrl.forms.orderConfigureForm" class="config-form">\n    <select-project selected-project="$ctrl.selectedProject" name-taken="$ctrl.nameTaken"></select-project>\n    <catalog-parameters\n      ng-if="$ctrl.parameterSchema.properties"\n      model="$ctrl.parameterData"\n      parameter-schema="$ctrl.parameterSchema">\n    </catalog-parameters>\n  </form>\n  <div ng-if="$ctrl.error" class="has-error">\n    <span class="help-block">{{$ctrl.error}}</span>\n  </div>\n</div>\n';
+    e.exports = '<div class="config-top">\n  <form name="$ctrl.forms.orderConfigureForm" class="config-form">\n    <select-project selected-project="$ctrl.selectedProject" name-taken="$ctrl.nameTaken"></select-project>\n    <catalog-parameters\n      ng-if="$ctrl.parameterSchema.properties"\n      model="$ctrl.parameterData"\n      parameter-schema="$ctrl.parameterSchema"\n      parameter-form-definition="$ctrl.parameterFormDefinition">\n    </catalog-parameters>\n  </form>\n  <div ng-if="$ctrl.error" class="has-error">\n    <span class="help-block">{{$ctrl.error}}</span>\n  </div>\n</div>\n';
 }, function(e, t) {
     e.exports = '<div class="config-top">\n  <div class="select-plans">\n    <h3>Select a Plan</h3>\n    <div ng-repeat="plan in $ctrl.serviceClass.resource.plans" class="radio">\n      <label>\n        <input\n          type="radio"\n          ng-model="$ctrl.planIndex"\n          ng-change="$ctrl.selectPlan(plan)"\n          value="{{$index}}">\n        <span class="plan-name">{{plan.externalMetadata.displayName || plan.name}}</span>\n        \x3c!-- TODO: truncate long text --\x3e\n        <div ng-if="plan.description">{{plan.description}}</div>\n        \x3c!-- TODO: show plan bullets --\x3e\n      </label>\n    </div>\n  </div>\n</div>\n';
 }, function(e, t) {
@@ -50,6 +50,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
     t.catalogParameters = {
         bindings: {
             parameterSchema: "<",
+            parameterFormDefinition: "<",
             model: "="
         },
         controller: r.CatalogParametersController,
@@ -979,12 +980,13 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
 }, function(e, t, n) {
     "use strict";
     t.__esModule = !0;
-    var r = function() {
+    var r = n(0), i = function() {
         function e() {
             this.ctrl = this;
         }
         return e.prototype.$onInit = function() {
-            this.ctrl.parameterForm = [ "*" ], this.ctrl.parameterFormDefaults = {
+            this.ctrl.parameterForm = this.cloneParameterForm(this.ctrl.parameterFormDefinition) || [ "*" ], 
+            this.ctrl.parameterFormDefaults = {
                 formDefaults: {
                     disableSuccessState: !0,
                     feedback: !1
@@ -994,9 +996,25 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
                     success: !0
                 }
             };
+        }, e.prototype.cloneParameterForm = function(t) {
+            if (r.isString(t)) return t;
+            if (r.isArray(t)) return r.map(t, r.bind(this.cloneParameterForm, this));
+            if (r.isObject(t)) {
+                var n = {};
+                return t.key && (n.key = t.key), e.ALLOWED_FORM_INPUT_TYPES[t.type] && (n.type = t.type), 
+                "fieldset" === n.type && r.isArray(t.items) && (t.title && (n.title = t.title), 
+                n.items = this.cloneParameterForm(t.items)), n.key || n.type ? n : null;
+            }
         }, e;
     }();
-    t.CatalogParametersController = r;
+    i.ALLOWED_FORM_INPUT_TYPES = {
+        fieldset: !0,
+        text: !0,
+        textarea: !0,
+        password: !0,
+        checkbox: !0,
+        select: !0
+    }, t.CatalogParametersController = i;
 }, function(e, t, n) {
     "use strict";
     t.__esModule = !0;
@@ -1429,7 +1447,8 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
         }, e.prototype.updateParameterSchema = function(t) {
             var n = i.get(t, "alphaInstanceCreateParameterSchema");
             i.has(n, [ "properties", e.REQUESTER_USERNAME_PARAM_NAME ]) ? (n = r.copy(n), delete n.properties[e.REQUESTER_USERNAME_PARAM_NAME], 
-            this.sendRequesterUsername = !0) : this.sendRequesterUsername = !1, this.ctrl.parameterSchema = n;
+            this.sendRequesterUsername = !0) : this.sendRequesterUsername = !1, this.ctrl.parameterSchema = n, 
+            this.ctrl.parameterFormDefinition = i.get(this, "ctrl.selectedPlan.externalMetadata.schemas.service_instance.create.openshift_form_definition");
         }, e.prototype.sortApplications = function() {
             if (this.deploymentConfigs && this.deployments && this.replicationControllers && this.replicaSets && this.statefulSets) {
                 var e = this.deploymentConfigs.concat(this.deployments).concat(this.replicationControllers).concat(this.replicaSets).concat(this.statefulSets);

--- a/src/components/catalog-parameters/catalog-parameters.component.ts
+++ b/src/components/catalog-parameters/catalog-parameters.component.ts
@@ -3,6 +3,7 @@ import {CatalogParametersController} from './catalog-parameters.controller';
 export const catalogParameters: angular.IComponentOptions = {
   bindings: {
     parameterSchema: '<',
+    parameterFormDefinition: '<',
     model: '='
   },
   controller: CatalogParametersController,

--- a/src/components/catalog-parameters/catalog-parameters.controller.ts
+++ b/src/components/catalog-parameters/catalog-parameters.controller.ts
@@ -1,11 +1,22 @@
+import * as _ from 'lodash';
+
 export class CatalogParametersController implements angular.IController {
+
+  private static ALLOWED_FORM_INPUT_TYPES = {
+    'fieldset': true,
+    'text': true,
+    'textarea': true,
+    'password': true,
+    'checkbox': true,
+    'select': true
+  };
 
   public ctrl: any = this;
 
   public $onInit() {
     // https://github.com/json-schema-form/angular-schema-form/blob/development/docs/index.md
-    // Show all fields in the schema.
-    this.ctrl.parameterForm = ['*'];
+    // If no form definition is supplied, show all fields in the schema using '*'.
+    this.ctrl.parameterForm = this.cloneParameterForm(this.ctrl.parameterFormDefinition) || ['*'];
     this.ctrl.parameterFormDefaults = {
       formDefaults: {
         // Add Bootstrap horizontal form styles.
@@ -28,4 +39,43 @@ export class CatalogParametersController implements angular.IController {
       }
     };
   }
+
+  // clones a form definition with only the accepted keys (key, type, items)
+  // and type values (fieldset, text, textarea, password, checkbox, select)
+  private cloneParameterForm(original: any) {
+
+    if (_.isString(original)) {
+      return original;
+    }
+
+    if (_.isArray(original)) {
+      return _.map(original, _.bind(this.cloneParameterForm, this));
+    }
+
+    if (_.isObject(original)) {
+      let newObject: any = {};
+
+      if (original.key) {
+        newObject.key = original.key;
+      }
+
+      if (CatalogParametersController.ALLOWED_FORM_INPUT_TYPES[original.type]) {
+        newObject.type = original.type;
+      }
+
+      if (newObject.type === 'fieldset' && _.isArray(original.items)) {
+        if (original.title) {
+          newObject.title = original.title;
+        }
+        newObject.items = this.cloneParameterForm(original.items);
+      }
+
+      //if empty/invalid, pass back null, not a truthy object
+      if (!newObject.key && !newObject.type) {
+        return null;
+      }
+
+      return newObject;
+    }
+  };
 }

--- a/src/components/order-service/order-service-configure.html
+++ b/src/components/order-service/order-service-configure.html
@@ -4,7 +4,8 @@
     <catalog-parameters
       ng-if="$ctrl.parameterSchema.properties"
       model="$ctrl.parameterData"
-      parameter-schema="$ctrl.parameterSchema">
+      parameter-schema="$ctrl.parameterSchema"
+      parameter-form-definition="$ctrl.parameterFormDefinition">
     </catalog-parameters>
   </form>
   <div ng-if="$ctrl.error" class="has-error">

--- a/src/components/order-service/order-service.controller.ts
+++ b/src/components/order-service/order-service.controller.ts
@@ -323,6 +323,7 @@ export class OrderServiceController implements angular.IController {
       this.sendRequesterUsername = false;
     }
     this.ctrl.parameterSchema = schema;
+    this.ctrl.parameterFormDefinition = _.get(this, 'ctrl.selectedPlan.externalMetadata.schemas.service_instance.create.openshift_form_definition');
   }
 
   private onProjectUpdate = () => {

--- a/src/styles/order-service.less
+++ b/src/styles/order-service.less
@@ -203,4 +203,16 @@
     min-height: 200px;
     overflow-y: auto;
   }
+
+  .schema-form-fieldset {
+    margin-bottom: 40px;
+    margin-top: 40px;
+
+    legend {
+      border-bottom: none;
+      border-top: solid 1px rgba(0, 0, 0, 0.15);
+      margin-bottom: 10px;
+      padding-top: 20px;
+    }
+  }
 }

--- a/test/services-view.spec.ts
+++ b/test/services-view.spec.ts
@@ -65,7 +65,7 @@ describe('servicesView', () => {
     var ctrl = componentTest.isoScope.$ctrl;
     expect(ctrl.currentFilter).toBe('all');
     expect(ctrl.currentSubFilter).toBe('all');
-    expect(ctrl.filteredItems.length).toBe(15);
+    expect(ctrl.filteredItems.length).toBe(16);
   });
 
   it('should display the initial categories and correct number of catalog cards', () => {
@@ -79,8 +79,8 @@ describe('servicesView', () => {
     // 'All' category should be selected and the current filter
     expect(jQuery(element).find('.nav-tabs-pf .active .services-category-heading').html()).toBe('All');
 
-    // 15 cards/services
-    expect(jQuery(element).find('.services-item-name').length).toBe(15);
+    // 16 cards/services
+    expect(jQuery(element).find('.services-item-name').length).toBe(16);
   });
 
   it('should filter sub-categories and cards when main category is clicked', () => {
@@ -275,8 +275,8 @@ describe('servicesView', () => {
 
     var element = componentTest.rawElement;
 
-    // 15 initial catalog items
-    expect(jQuery(element).find('.services-item-name').length).toBe(15);
+    // 16 initial catalog items
+    expect(jQuery(element).find('.services-item-name').length).toBe(16);
 
     //Get Filter Dropdown
     var filterDropdown = jQuery(element).find('span[uib-dropdown]');
@@ -289,8 +289,8 @@ describe('servicesView', () => {
 
     enterFilterKeyword(keyWordInput, "test");
 
-    // 9 catalog items with 'test' keyword
-    expect(jQuery(element).find('.services-item-name').length).toBe(9);
+    // 10 catalog items with 'test' keyword
+    expect(jQuery(element).find('.services-item-name').length).toBe(10);
 
     // 1 active filter tag
     let keywordFilterTags: any = jQuery(element).find('.active-filter.label.label-info');
@@ -312,14 +312,14 @@ describe('servicesView', () => {
     // clear second keyword filter
     componentTest.eventFire(keywordFilterTags.eq(1).find('.pficon-close')[0], 'click');
 
-    // back to 9 catalog items with 'test' keyword
-    expect(jQuery(element).find('.services-item-name').length).toBe(9);
+    // back to 10 catalog items with 'test' keyword
+    expect(jQuery(element).find('.services-item-name').length).toBe(10);
 
     // remove all filters
     componentTest.eventFire(jQuery(element).find('.clear-filters')[0], 'click');
 
-    // back to the original 15 catalog items
-    expect(jQuery(element).find('.services-item-name').length).toBe(15);
+    // back to the original 16 catalog items
+    expect(jQuery(element).find('.services-item-name').length).toBe(16);
 
     // no keyword filter tags
     expect(jQuery(element).find('.active-filter.label.label-info').length).toBe(0);
@@ -342,8 +342,8 @@ describe('servicesView', () => {
     enterFilterKeyword(keyWordInput, "test");
     componentTest.scope.$digest();
 
-    // 9 catalog items with 'test' keyword
-    expect(jQuery(element).find('.services-item-name').length).toBe(9);
+    // 10 catalog items with 'test' keyword
+    expect(jQuery(element).find('.services-item-name').length).toBe(10);
 
     // 1 active filter tag
     let keywordFilterTags: any = jQuery(element).find('.active-filter.label.label-info');


### PR DESCRIPTION
Allows the OpenShift UI to enforce order, grouping, and display type, if that information is supplied by the broker.  Brokers are responsible for adding the form definition in the plan metadata as `schemas.service_instance.create.form_definition`  (A similar path for service_binding.create can also be supplied this way, but out of scope fort his PR).   

Unfortunately, regarding grouping, fieldset and section html is generated properly, but has no visual difference.  This would take additional work to style appropriately. (picture below)

Example broker code:
https://github.com/openshift/ansible-service-broker/pull/386 

Example json gist:
https://gist.github.com/cfchase/8614236dcb8e22cc0aa8a2b4f1ee52d0

Screenshots
Full Wizard:
![wizard-full](https://user-images.githubusercontent.com/1448375/29636810-0e7a893e-8820-11e7-9017-f7461ef7021f.png)

Example display types of fields:
![wizard-fields-1](https://user-images.githubusercontent.com/1448375/29636813-12d3737e-8820-11e7-8ab5-e1831076e0ab.png)
![wizard-fields-2](https://user-images.githubusercontent.com/1448375/29636817-160ad942-8820-11e7-9bbd-ad4efd251c9a.png)
![wizard-fields-3](https://user-images.githubusercontent.com/1448375/29636821-17ea7a10-8820-11e7-9f91-12747fa8308b.png)

Fieldset not styled:
![wizard-fieldset-no-style](https://user-images.githubusercontent.com/1448375/29636906-5f96d872-8820-11e7-91d5-338e106f7ecd.png)




