### PR TITLE
Update angular-patternfly dependency to "at least" syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@ dist/*.svg
 dist/*.gif
 dist/*.jpg
 dist/*.png
-
+.DS_Store

--- a/bower.json
+++ b/bower.json
@@ -35,7 +35,7 @@
     "angular-sanitize": "1.5.11",
     "angular-route": "1.5.11",
     "angular-bootstrap": "0.14.3",
-    "angular-patternfly": "~4.7.1",
+    "angular-patternfly": ">=4.7.1 <5.0.0",
     "angular-schema-form": "^0.8.13",
     "patternfly": "~3.26.1",
     "jquery": "~3.2.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "angular-animate": "1.5.11",
     "angular-drag-and-drop-lists": "2.0.0",
     "angular-moment": "1.0.0",
-    "angular-patternfly": "~4.7.1",
+    "angular-patternfly": ">=4.7.1 <5.0.0",
     "angular-sanitize": "1.5.11",
     "angular-schema-form": "^0.8.13",
     "angular-schema-form-bootstrap": "^0.2.0",


### PR DESCRIPTION
- use `>` for angular-patternfly 
- add DS_Store to `.gitignore`

We are using `~` right now, which allows for a range in the patch.  I think we should use `>`. 

Perhaps `>=` would be better:

`"angular-patternfly": ">=4.3.0"`

 as we should be able to expect future minor changes to work as well. We can add a limit if it makes sense:

`"angular-patternfly": ">=4.3.0 <5.0.0"`

This should clarify that `openshift-web-console` is the source of truth & simplify bumping the dependencies.  It does assume `semver` is followed closely & breaking changes will not be introduced without a major version bump.

@spadgett @jeff-phillips-18 ?

Relevant for [this PR](https://github.com/openshift/origin-web-console/pull/1988)