### PR TITLE
Update catalog-parameters form definition when changed.

### DIFF
--- a/dist/origin-web-catalogs.js
+++ b/dist/origin-web-catalogs.js
@@ -1016,7 +1016,6 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             this.ctrl = this;
         }
         return e.prototype.$onInit = function() {
-            this.ctrl.parameterForm = this.cloneParameterForm(this.ctrl.parameterFormDefinition) || [ "*" ], 
             this.ctrl.parameterFormDefaults = {
                 formDefaults: {
                     disableSuccessState: !0,
@@ -1027,6 +1026,8 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
                     success: !0
                 }
             };
+        }, e.prototype.$onChanges = function(e) {
+            e.parameterFormDefinition && (this.ctrl.parameterForm = this.cloneParameterForm(this.ctrl.parameterFormDefinition) || [ "*" ]);
         }, e.prototype.cloneParameterForm = function(t) {
             if (n.isString(t)) return t;
             if (n.isArray(t)) return n.map(t, n.bind(this.cloneParameterForm, this));

--- a/src/components/catalog-parameters/catalog-parameters.controller.ts
+++ b/src/components/catalog-parameters/catalog-parameters.controller.ts
@@ -14,9 +14,6 @@ export class CatalogParametersController implements angular.IController {
   public ctrl: any = this;
 
   public $onInit() {
-    // https://github.com/json-schema-form/angular-schema-form/blob/development/docs/index.md
-    // If no form definition is supplied, show all fields in the schema using '*'.
-    this.ctrl.parameterForm = this.cloneParameterForm(this.ctrl.parameterFormDefinition) || ['*'];
     this.ctrl.parameterFormDefaults = {
       formDefaults: {
         // Add Bootstrap horizontal form styles.
@@ -38,6 +35,14 @@ export class CatalogParametersController implements angular.IController {
         success: true
       }
     };
+  }
+
+  public $onChanges(onChangesObj: angular.IOnChangesObject) {
+    if (onChangesObj.parameterFormDefinition) {
+      // https://github.com/json-schema-form/angular-schema-form/blob/development/docs/index.md
+      // If no form definition is supplied, show all fields in the schema using '*'.
+      this.ctrl.parameterForm = this.cloneParameterForm(this.ctrl.parameterFormDefinition) || ['*'];
+    }
   }
 
   // clones a form definition with only the accepted keys (key, type, items)


### PR DESCRIPTION
When changing plans, the form definition wasn't being updated.  As a result, only the first plan's form definition was shown.  This change updates the displayed form definition whenever the input form definition is changed (such as by changing plans)