### PR TITLE
Workaround for webpack-dev-server issue with Safari

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -5,6 +5,7 @@
 // To change configuration for local development, copy this file to
 // assets/app/config.local.js and edit the copy.
 window.DEV_SERVER_PORT = 9001;
+window.DEV_TOOL_SETTING = 'cheap-eval-source-map';
 
 window.OPENSHIFT_CONFIG = {
   apis: {

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -14,9 +14,10 @@ try {
 
 var useHTTPS = !window.MOCK_ORIGIN_SERVICES;
 var port = window.DEV_SERVER_PORT || 9001;
+var devtoolMap = window.DEV_TOOL_SETTING || 'cheap-eval-source-map';
 
 module.exports = webpackMerge(commonConfig, {
-  devtool: 'cheap-eval-source-map',
+  devtool: devtoolMap,
 
   output: {
     path: helpers.root('dist'),


### PR DESCRIPTION
https://github.com/webpack/webpack-dev-server/issues/1090 includes details of the webpack-dev-server issue.  

**Important: in order to make use of this fix, add:**

```
window.DEV_TOOL_SETTING = 'inline-source-map';
```

to your `app/config.local.js` file when you need to test in Safari.  Note this will significantly slow down build and rebuild, so use it only when testing in Safari.

Thanks, @jeff-phillips-18, for the assist on this one.