### PR TITLE
Bug 1492991 - Remove alpha prefix from service catalog properties

### DIFF
--- a/app/mockServices/mockData/services.ts
+++ b/app/mockServices/mockData/services.ts
@@ -7,7 +7,7 @@ export const servicesData = {
     },
     bindable: true,
     description: 'BUILDS SOURCE CODE',
-    alphaTags: ['java', 'nodejs'],
+    tags: ['java', 'nodejs'],
     externalMetadata: {
       displayName: 'Test ServiceClass Java-Node.js',
       longDescription: 'Build and run Java applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/openshift-s2i/s2i-wildfly/blob/mast…',
@@ -72,7 +72,7 @@ export const servicesData = {
     },
     bindable: true,
     description: 'BUILDS SOURCE CODE',
-    alphaTags: ['nodejs'],
+    tags: ['nodejs'],
     externalMetadata: {
       displayName: 'Test ServiceClass Node.js',
       longDescription: 'run nodejs applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/openshift-s2i/s2i-wildfly/blob/mast…',
@@ -90,7 +90,7 @@ export const servicesData = {
     },
     bindable: true,
     description: 'BUILDS SOURCE CODE',
-    alphaTags: ['perl'],
+    tags: ['perl'],
     externalMetadata: {
       displayName: 'Test ServiceClass Perl',
       longDescription: 'run Perl applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/openshift-s2i/s2i-wildfly/blob/mast…',
@@ -108,7 +108,7 @@ export const servicesData = {
     },
     bindable: true,
     description: 'BUILDS SOURCE CODE',
-    alphaTags: ['ruby', 'mongodb'],
+    tags: ['ruby', 'mongodb'],
     externalMetadata: {
       displayName: 'Test ServiceClass Ruby-Mongo',
       longDescription: 'run ruby applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/openshift-s2i/s2i-wildfly/blob/mast…',
@@ -126,7 +126,7 @@ export const servicesData = {
     },
     bindable: true,
     description: 'BUILDS SOURCE CODE',
-    alphaTags: ['php'],
+    tags: ['php'],
     externalMetadata: {
       displayName: 'Test ServiceClass PHP',
       longDescription: 'run PHP applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/openshift-s2i/s2i-wildfly/blob/mast…',
@@ -144,7 +144,7 @@ export const servicesData = {
     },
     bindable: true,
     description: 'BUILDS SOURCE CODE',
-    alphaTags: ['mongodb'],
+    tags: ['mongodb'],
     externalMetadata: {
       displayName: 'Test ServiceClass MongoDB',
       longDescription: 'run MongoDB applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/openshift-s2i/s2i-wildfly/blob/mast…',
@@ -162,7 +162,7 @@ export const servicesData = {
     },
     bindable: true,
     description: 'BUILDS SOURCE CODE',
-    alphaTags: ['mysql'],
+    tags: ['mysql'],
     externalMetadata: {
       displayName: 'Test ServiceClass mySQL',
       longDescription: 'run MongoDB applications. For more information about using this builder image, including OpenShift considerations, see https://github.com/openshift-s2i/s2i-wildfly/blob/mast…',
@@ -180,7 +180,7 @@ export const servicesData = {
     },
     bindable: true,
     description: 'BUILDS SOURCE CODE',
-    alphaTags: ['fooBar'],
+    tags: ['fooBar'],
     externalMetadata: {
       displayName: 'Test ServiceClass Other',
       longDescription: 'some other service',
@@ -198,7 +198,7 @@ export const servicesData = {
     },
     bindable: true,
     description: 'BUILDS SOURCE CODE',
-    alphaTags: ['jenkins'],
+    tags: ['jenkins'],
     externalMetadata: {
       displayName: 'Test ServiceClass jenkins',
       longDescription: 'some other service',
@@ -216,7 +216,7 @@ export const servicesData = {
     },
     bindable: true,
     description: 'TEST APB SERVICE',
-    alphaTags: ['databases', 'postgresql'],
+    tags: ['databases', 'postgresql'],
     externalMetadata: {
       displayName: 'Test ServiceClass PostgreSQL DB APB',
       longDescription: 'A sample APB which deploys a PostgreSQL Database',
@@ -271,7 +271,7 @@ export const servicesData = {
             }
           }
         },
-        alphaInstanceCreateParameterSchema: {
+        instanceCreateParameterSchema: {
           "$schema": "http://json-schema.org/draft-04/schema",
           additionalProperties: false,
           properties: {
@@ -298,7 +298,7 @@ export const servicesData = {
           ],
           type: "object"
         },
-        alphaServiceInstanceCredentialCreateParameterSchema: {
+        serviceInstanceCredentialCreateParameterSchema: {
           "$schema": "http://json-schema.org/draft-04/schema",
           additionalProperties: false,
           properties: {

--- a/dist/origin-web-catalogs.js
+++ b/dist/origin-web-catalogs.js
@@ -5,7 +5,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
 }, function(e, t) {
     e.exports = $;
 }, function(e, t) {}, function(e, t) {
-    e.exports = '<a href="" class="catalog-search-match" ng-class="{\'no-matches\': match.model.id === \'viewNone\'}">\n  <span class="catalog-search-match-icon" ng-if="match.model.id !== \'viewAll\' && match.model.id !== \'viewNone\'">\n    <span ng-if="match.model.imageUrl"><img ng-src="{{match.model.imageUrl}}"></span>\n    <span ng-if="!match.model.imageUrl && match.model.iconClass" ng-class="match.model.iconClass" class="icon"></span>\n  </span>\n  <div class="catalog-search-match-info" ng-if="match.model.id !== \'viewAll\' && match.model.id !== \'viewNone\'">\n    <div class="catalog-search-match-label">\n      {{match.label}}\n    </div>\n    <div class="catalog-search-match-description">\n      <span ng-repeat="tag in (match.model.tags || match.model.resource.alphaTags)" class="tag small text-muted">\n        {{tag}}\n      </span>\n    </div>\n  </div>\n  <span ng-if="match.model.id === \'viewNone\'" class="catalog-search-show-none">\n    {{match.model.text}}\n  </span>\n  <span ng-if="match.model.id === \'viewAll\'" class="catalog-search-show-all">\n    {{match.model.text}}  <span class="fa fa-angle-right"></span>\n  </span>\n</a>\n';
+    e.exports = '<a href="" class="catalog-search-match" ng-class="{\'no-matches\': match.model.id === \'viewNone\'}">\n  <span class="catalog-search-match-icon" ng-if="match.model.id !== \'viewAll\' && match.model.id !== \'viewNone\'">\n    <span ng-if="match.model.imageUrl"><img ng-src="{{match.model.imageUrl}}"></span>\n    <span ng-if="!match.model.imageUrl && match.model.iconClass" ng-class="match.model.iconClass" class="icon"></span>\n  </span>\n  <div class="catalog-search-match-info" ng-if="match.model.id !== \'viewAll\' && match.model.id !== \'viewNone\'">\n    <div class="catalog-search-match-label">\n      {{match.label}}\n    </div>\n    <div class="catalog-search-match-description">\n      <span ng-repeat="tag in (match.model.tags || match.model.resource.tags)" class="tag small text-muted">\n        {{tag}}\n      </span>\n    </div>\n  </div>\n  <span ng-if="match.model.id === \'viewNone\'" class="catalog-search-show-none">\n    {{match.model.text}}\n  </span>\n  <span ng-if="match.model.id === \'viewAll\'" class="catalog-search-show-all">\n    {{match.model.text}}  <span class="fa fa-angle-right"></span>\n  </span>\n</a>\n';
 }, function(e, t) {
     e.exports = '<bind-application-form application-name="$ctrl.name"\n                       form-name="$ctrl.bindForm"\n                       allow-no-binding="true"\n                       service-instances="$ctrl.serviceInstances"\n                       service-classes="$ctrl.serviceClasses"\n                       service-to-bind="$ctrl.serviceToBind">\n</bind-application-form>\n';
 }, function(e, t) {
@@ -805,7 +805,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
         }, e.prototype.getLongDescription = function() {
             return i.get(this.resource, "externalMetadata.longDescription") || "";
         }, e.prototype.getTags = function() {
-            return i.get(this.resource, "alphaTags") || [];
+            return i.get(this.resource, "tags") || [];
         }, e.prototype.getVendor = function() {
             var e = i.get(this.resource, "externalMetadata.providerDisplayName");
             return this.catalogSrv.getPublisherSynonym(e);
@@ -1488,11 +1488,11 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             this.bindParametersStep.hidden = this.bindStep.hidden || "none" === this.ctrl.bindType || !i.has(this.ctrl, "bindParameterSchema.properties"), 
             this.bindParametersStep.allowed = this.bindStep.valid;
         }, e.prototype.updateParameterSchema = function(t) {
-            var r = i.get(t, "alphaInstanceCreateParameterSchema");
+            var r = i.get(t, "instanceCreateParameterSchema");
             i.has(r, [ "properties", e.REQUESTER_USERNAME_PARAM_NAME ]) ? (r = n.copy(r), delete r.properties[e.REQUESTER_USERNAME_PARAM_NAME], 
             this.sendRequesterUsername = !0) : this.sendRequesterUsername = !1, this.ctrl.parameterSchema = r, 
             this.ctrl.parameterFormDefinition = i.get(this, "ctrl.selectedPlan.externalMetadata.schemas.service_instance.create.openshift_form_definition"), 
-            this.ctrl.bindParameterSchema = i.get(t, "alphaServiceInstanceCredentialCreateParameterSchema");
+            this.ctrl.bindParameterSchema = i.get(t, "serviceInstanceCredentialCreateParameterSchema");
         }, e.prototype.getParameters = function() {
             var t = i.omitBy(this.ctrl.parameterData, function(e) {
                 return "" === e;

--- a/src/components/catalog-search/catalog-search-result.html
+++ b/src/components/catalog-search/catalog-search-result.html
@@ -8,7 +8,7 @@
       {{match.label}}
     </div>
     <div class="catalog-search-match-description">
-      <span ng-repeat="tag in (match.model.tags || match.model.resource.alphaTags)" class="tag small text-muted">
+      <span ng-repeat="tag in (match.model.tags || match.model.resource.tags)" class="tag small text-muted">
         {{tag}}
       </span>
     </div>

--- a/src/components/order-service/order-service.controller.ts
+++ b/src/components/order-service/order-service.controller.ts
@@ -367,7 +367,7 @@ export class OrderServiceController implements angular.IController {
   };
 
   private updateParameterSchema(plan: any) {
-    let schema: any = _.get(plan, 'alphaInstanceCreateParameterSchema');
+    let schema: any = _.get(plan, 'instanceCreateParameterSchema');
     if (_.has(schema, ['properties', OrderServiceController.REQUESTER_USERNAME_PARAM_NAME])) {
       schema = angular.copy(schema);
       delete schema.properties[OrderServiceController.REQUESTER_USERNAME_PARAM_NAME];
@@ -378,7 +378,7 @@ export class OrderServiceController implements angular.IController {
     this.ctrl.parameterSchema = schema;
     this.ctrl.parameterFormDefinition = _.get(this, 'ctrl.selectedPlan.externalMetadata.schemas.service_instance.create.openshift_form_definition');
 
-    this.ctrl.bindParameterSchema = _.get(plan, 'alphaServiceInstanceCredentialCreateParameterSchema');
+    this.ctrl.bindParameterSchema = _.get(plan, 'serviceInstanceCredentialCreateParameterSchema');
   }
 
   private onProjectUpdate = () => {

--- a/src/services/catalog.service.ts
+++ b/src/services/catalog.service.ts
@@ -363,7 +363,7 @@ export class ServiceItem implements IServiceItem {
   }
 
   private getTags(): string[] {
-    return _.get(this.resource, 'alphaTags') as string[] || [];
+    return _.get(this.resource, 'tags') as string[] || [];
   }
 
   private getVendor(): string {

--- a/test/services-view.spec.ts
+++ b/test/services-view.spec.ts
@@ -153,7 +153,7 @@ describe('servicesView', () => {
           "name": "mycat-database",
           "uid": "10",
         },
-        alphaTags: [
+        tags: [
           "mycat",
           "database"
         ]
@@ -164,7 +164,7 @@ describe('servicesView', () => {
           "name": "mycat-other",
           "uid": "11",
         },
-        alphaTags: [
+        tags: [
           "mycat",
           "foobar"
         ]
@@ -214,7 +214,7 @@ describe('servicesView', () => {
           "name": "mycat-database",
           "uid": "10",
         },
-        alphaTags: [
+        tags: [
           "mycata",
           "mycatb",
           "database"


### PR DESCRIPTION
https://trello.com/c/y1lbFrbp

Since service-catalog 0.0.18, the alpha prefix has been removed from all fields in favor of feature gating. Make the corresponding API changes in the web catalog.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1492991