### PR TITLE
In ordering panel, if user selects project which they have 'view only' access, show error

### DIFF
--- a/dist/origin-web-catalogs.js
+++ b/dist/origin-web-catalogs.js
@@ -1787,7 +1787,10 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             var r = [ "metadata.name", 'metadata.annotations["openshift.io/display-name"]' ], n = this.KeywordService.generateKeywords(e);
             return this.KeywordService.filterForKeywords(t, r, n);
         }, e.prototype.canIAddToProject = function() {
-            return this.ctrl.forms.selectProjectForm.selectProject.$setValidity("cannotAddToProject", !0);
+            var e = this, t = !0, r = i.get(this.ctrl.selectedProject, "metadata.name");
+            this.isNewProject() || this.AuthorizationService.getProjectRules(r).then(function() {
+                t = e.AuthorizationService.canIAddToProject(r), e.ctrl.forms.selectProjectForm.selectProject.$setValidity("cannotAddToProject", t);
+            }), this.ctrl.forms.selectProjectForm.selectProject.$setValidity("cannotAddToProject", t);
         }, e.prototype.updateProjects = function(t) {
             if (this.largeProjectList = i.size(t) >= e.LARGE_PROJECT_LIST_SIZE, this.largeProjectList) return this.ctrl.placeholder = "Filter projects by name", 
             this.ctrl.searchEnabled = !0, this.ctrl.refreshDelay = 500, void (this.projects = t);
@@ -1804,8 +1807,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             this.ctrl.searchEnabled = !i.isEmpty(n), this.ctrl.refreshDelay = 0, this.ctrl.existingProjectNames = i.map(t, "metadata.name"), 
             this.ctrl.selectedProject || 1 !== i.size(this.projects) || (this.ctrl.selectedProject = this.projects[0], 
             this.onSelectProjectChange()), this.ctrl.canCreate && (this.projects.unshift(r), 
-            1 === i.size(this.projects) && (this.ctrl.selectedProject = r, this.onSelectProjectChange())), 
-            this.canIAddToProject();
+            1 === i.size(this.projects) && (this.ctrl.selectedProject = r, this.onSelectProjectChange()));
         }, e.prototype.listProjects = function() {
             var e = this;
             this.ctrl.availableProjects ? this.updateProjects(this.ctrl.availableProjects) : this.ProjectsService.list().then(function(t) {

--- a/src/components/select-project/select-project.controller.ts
+++ b/src/components/select-project/select-project.controller.ts
@@ -158,18 +158,19 @@ export class SelectProjectController implements angular.IController {
     return this.KeywordService.filterForKeywords(candidates, searchFields, keywords);
   };
 
-  private canIAddToProject(): boolean {
+  private canIAddToProject() {
     let canIAddToProject: boolean = true;
 
-    // TODO AuthorizationService.canIAddToProject assumes that the ProjectsService.get has already completed performed
-    // but currently this happens after project change events fire and it happens in the various dialog controllers, not
-    // as part of this component.  For now always return true until we can resolve this.
-    //
-    // if (!this.isNewProject()) {
-    //   canIAddToProject = this.AuthorizationService.canIAddToProject(_.get(this.ctrl.selectedProject, 'metadata.name'));
-    // }
+    var projectName = _.get(this.ctrl.selectedProject, 'metadata.name');
 
-    return this.ctrl.forms.selectProjectForm.selectProject.$setValidity('cannotAddToProject', canIAddToProject);
+    if (!this.isNewProject()) {
+      this.AuthorizationService.getProjectRules(projectName).then( () => {
+        canIAddToProject = this.AuthorizationService.canIAddToProject(projectName);
+        this.ctrl.forms.selectProjectForm.selectProject.$setValidity('cannotAddToProject', canIAddToProject);
+      });
+    }
+
+    this.ctrl.forms.selectProjectForm.selectProject.$setValidity('cannotAddToProject', canIAddToProject);
   }
 
   private updateProjects(projects: any) {
@@ -219,8 +220,6 @@ export class SelectProjectController implements angular.IController {
         this.onSelectProjectChange();
       }
     }
-
-    this.canIAddToProject();
   }
 
   private listProjects() {


### PR DESCRIPTION
Issue was that the 'canIAddToProject' rule was expected to be loaded via the project 'rules' via a 'get'.  Fixed so that project rules are loaded if they are not in the AuthorizationService project rules cache.

Screenshots of launching the Ordering Panel without ever going to a View Project screen:

![image](https://user-images.githubusercontent.com/12733153/31086175-2261a660-a767-11e7-9763-94352f1ac883.png)

![image](https://user-images.githubusercontent.com/12733153/31086178-27298a64-a767-11e7-84eb-c8885074d3c5.png)

Fixes #318

