### PR TITLE
IE11 needs a defined width on the flex container to prevent overflow

### DIFF
--- a/dist/less/services-view.less
+++ b/dist/less/services-view.less
@@ -125,6 +125,7 @@ services-view,
     flex: 1 1 auto;
     flex-wrap: wrap;
     padding-bottom: 30px; // give equal space below last row of service-items
+    width: 100%; // IE11 needs width associated with flex
     z-index: 9; // elevate so that toggling tiles that cause repositioning do not overlay main content block
   }
 

--- a/dist/origin-web-catalogs.css
+++ b/dist/origin-web-catalogs.css
@@ -1043,6 +1043,7 @@ services-view .vendor-info-icon,
   flex: 1 1 auto;
   flex-wrap: wrap;
   padding-bottom: 30px;
+  width: 100%;
   z-index: 9;
 }
 .services-view .services-items-filter {

--- a/src/styles/services-view.less
+++ b/src/styles/services-view.less
@@ -125,6 +125,7 @@ services-view,
     flex: 1 1 auto;
     flex-wrap: wrap;
     padding-bottom: 30px; // give equal space below last row of service-items
+    width: 100%; // IE11 needs width associated with flex
     z-index: 9; // elevate so that toggling tiles that cause repositioning do not overlay main content block
   }
 


### PR DESCRIPTION
Fixes https://github.com/openshift/origin-web-catalog/issues/462

<img width="642" alt="screen shot 2017-10-03 at 11 24 51 am" src="https://user-images.githubusercontent.com/1874151/31137640-d75d1392-a839-11e7-8b59-e3dc77bb0908.png">
