### PR TITLE
Adopt more service catalog API changes

### DIFF
--- a/app/mockServices/mockAPI.service.ts
+++ b/app/mockServices/mockAPI.service.ts
@@ -47,11 +47,11 @@ export class APIService implements IAPIService {
     let preferredVersions = {
         // Using the anticipated name for the resources, even though they aren't yet prefixed with `cluster`.
         // https://github.com/kubernetes-incubator/service-catalog/issues/1288
-        clusterserviceclasses:            {group: 'servicecatalog.k8s.io',      resource: 'serviceclasses' },
-        clusterserviceplans:              {group: 'servicecatalog.k8s.io',      resource: 'serviceplans' },
+        clusterserviceclasses:            {group: 'servicecatalog.k8s.io',      resource: 'clusterserviceclasses' },
+        clusterserviceplans:              {group: 'servicecatalog.k8s.io',      resource: 'clusterserviceplans' },
         imagestreams:                     {group: 'image.openshift.io',         version: 'v1',      resource: 'imagestreams' },
         // Using the anticipated name for this resource, even though it's not currently called servicebindings.
-        servicebindings:                  {group: 'servicecatalog.k8s.io',      resource: 'serviceinstancecredentials' },
+        servicebindings:                  {group: 'servicecatalog.k8s.io',      resource: 'servicebindings' },
         serviceinstances:                 {group: 'servicecatalog.k8s.io',      resource: 'serviceinstances' },
         templates:                        {group: 'template.openshift.io',      verison: 'v1',      resource: 'templates' }
     };

--- a/app/mockServices/mockData.service.ts
+++ b/app/mockServices/mockData.service.ts
@@ -206,10 +206,10 @@ export class DataService implements IDataService {
     resource = this.normalizeResource(resource);
 
     switch (resource) {
-    case 'serviceclasses':
+    case 'clusterserviceclasses':
       returnData = new DataServiceData(servicesData);
       break;
-    case 'serviceplans':
+    case 'clusterserviceplans':
       returnData = new DataServiceData(plansData);
       break;
     case 'projects':

--- a/app/mockServices/mockData/plans.ts
+++ b/app/mockServices/mockData/plans.ts
@@ -1,6 +1,7 @@
 export const plansData = {
   // test-serviceclass-java-nodejs
   'rh-ded-topic': {
+    kind: 'ClusterServicePlan',
     metadata: {
       name: 'rh-ded-topic',
       uid: '1'
@@ -58,6 +59,7 @@ export const plansData = {
     }
   },
   'rh-ded-queue': {
+    kind: 'ClusterServicePlan',
     metadata: {
       name: 'rh-ded-queue',
       uid: '2'
@@ -76,6 +78,7 @@ export const plansData = {
     }
   },
   'rh-shared-topic': {
+    kind: 'ClusterServicePlan',
     metadata: {
       name: 'rh-shared-topic',
       uid: '3'
@@ -94,6 +97,7 @@ export const plansData = {
     }
   },
   'rh-shared-queue': {
+    kind: 'ClusterServicePlan',
     metadata: {
       name: 'rh-shared-queue',
       uid: '4'
@@ -111,6 +115,7 @@ export const plansData = {
     }
   },
   'self-ded-topic': {
+    kind: 'ClusterServicePlan',
     metadata: {
       name: 'self-ded-topic',
       uid: '5',
@@ -129,6 +134,7 @@ export const plansData = {
     }
   },
   'self-ded-queue': {
+    kind: 'ClusterServicePlan',
     metadata: {
       name: 'self-ded-queue',
       uid: '6'
@@ -148,6 +154,7 @@ export const plansData = {
   },
   // test-serviceclass-nodejs
   'test-serviceclass-nodejs-plan': {
+    kind: 'ClusterServicePlan',
     metadata: {
       name: 'test-serviceclass-nodejs-plan',
       uid: '7'
@@ -167,6 +174,7 @@ export const plansData = {
   },
   // test-serviceclass-perl
   'test-serviceclass-perl-plan': {
+    kind: 'ClusterServicePlan',
     metadata: {
       name: 'test-serviceclass-perl-plan',
       uid: '8'
@@ -186,6 +194,7 @@ export const plansData = {
   },
   // test-serviceclass-ruby
   'test-serviceclass-ruby-plan': {
+    kind: 'ClusterServicePlan',
     metadata: {
       name: 'test-serviceclass-ruby-plan',
       uid: '9'
@@ -205,6 +214,7 @@ export const plansData = {
   },
   // test-serviceclass-php
   'test-serviceclass-php-plan': {
+    kind: 'ClusterServicePlan',
     metadata: {
       name: 'test-serviceclass-php-plan',
       uid: '10'
@@ -224,6 +234,7 @@ export const plansData = {
   },
   // test-serviceclass-mongo
   'test-serviceclass-mongo-plan': {
+    kind: 'ClusterServicePlan',
     metadata: {
       name: 'test-serviceclass-mongo-plan',
       uid: '10'
@@ -243,6 +254,7 @@ export const plansData = {
   },
   // test-serviceclass-mysql
   'test-serviceclass-mysql-plan': {
+    kind: 'ClusterServicePlan',
     metadata: {
       name: 'test-serviceclass-mysql-plan',
       uid: '11'
@@ -262,6 +274,7 @@ export const plansData = {
   },
   // test-serviceclass-other
   'test-serviceclass-other-plan': {
+    kind: 'ClusterServicePlan',
     metadata: {
       name: 'test-serviceclass-other-plan',
       uid: '12'
@@ -281,6 +294,7 @@ export const plansData = {
   },
   // test-serviceclass-jenkins
   'test-serviceclass-jenkins-plan': {
+    kind: 'ClusterServicePlan',
     metadata: {
       name: 'test-serviceclass-jenkins-plan',
       uid: '13'
@@ -300,6 +314,7 @@ export const plansData = {
   },
   // test-serviceclass-pg-apb
   'pg-apb-default': {
+    kind: 'ClusterServicePlan',
     metadata: {
       name: "pg-apb-default",
       uid: '14'

--- a/app/mockServices/mockData/services.ts
+++ b/app/mockServices/mockData/services.ts
@@ -1,6 +1,6 @@
 export const servicesData = {
   "test-serviceclass-java": {
-    kind: 'ServiceClass',
+    kind: 'ClusterServiceClass',
     metadata: {
       name: "test-serviceclass-java-nodejs",
       uid: "1"
@@ -19,7 +19,7 @@ export const servicesData = {
     }
   },
   "test-serviceclass-nodejs": {
-    kind: 'ServiceClass',
+    kind: 'ClusterServiceClass',
     metadata: {
       name: "test-serviceclass-nodejs",
       uid: "2"
@@ -36,7 +36,7 @@ export const servicesData = {
     }
   },
   "test-serviceclass-perl": {
-    kind: 'ServiceClass',
+    kind: 'ClusterServiceClass',
     metadata: {
       name: "test-serviceclass-perl",
       uid: "3"
@@ -53,7 +53,7 @@ export const servicesData = {
     }
   },
   "test-serviceclass-ruby": {
-    kind: 'ServiceClass',
+    kind: 'ClusterServiceClass',
     metadata: {
       name: "test-serviceclass-ruby-mongo",
       uid: "4"
@@ -70,7 +70,7 @@ export const servicesData = {
     }
   },
   "test-serviceclass-php": {
-    kind: 'ServiceClass',
+    kind: 'ClusterServiceClass',
     metadata: {
       name: "test-serviceclass-php",
       uid: "5"
@@ -87,7 +87,7 @@ export const servicesData = {
     }
   },
   "test-serviceclass-mongo": {
-    kind: 'ServiceClass',
+    kind: 'ClusterServiceClass',
     metadata: {
       name: "test-serviceclass-mongo",
       uid: "6"
@@ -104,7 +104,7 @@ export const servicesData = {
     }
   },
   "test-serviceclass-mysql": {
-    kind: 'ServiceClass',
+    kind: 'ClusterServiceClass',
     metadata: {
       name: "test-serviceclass-mysql",
       uid: "7"
@@ -121,7 +121,7 @@ export const servicesData = {
     }
   },
   "test-serviceclass-other": {
-    kind: 'ServiceClass',
+    kind: 'ClusterServiceClass',
     metadata: {
       name: "test-serviceclass-other",
       uid: "8",
@@ -138,7 +138,7 @@ export const servicesData = {
     }
   },
   "test-serviceclass-jenkins": {
-    kind: 'ServiceClass',
+    kind: 'ClusterServiceClass',
     metadata: {
       name: "test-serviceclass-jenkins",
       uid: "9"
@@ -155,7 +155,7 @@ export const servicesData = {
     }
   },
   "test-serviceclass-pg-apb": {
-    kind: 'ServiceClass',
+    kind: 'ClusterServiceClass',
     metadata: {
       name: "test-serviceclass-pg-apb",
       uid: "10",
@@ -184,6 +184,26 @@ export const servicesData = {
         displayName: 'THIS SERVICE SHOULD NOT SHOW UP IN THE UI',
         longDescription: 'It has the `hidden` tag, which means it should not be displayed.',
       }
+    }
+  },
+  "test-serviceclass-removed": {
+    kind: 'ServiceClass',
+    metadata: {
+      name: "test-serviceclass-removed",
+      uid: "12",
+    },
+    spec: {
+      bindable: true,
+      description: 'THIS SERVICE SHOULD NOT SHOW UP IN THE UI.',
+      tags: ['databases', 'postgresql'],
+      externalMetadata: {
+        displayName: 'THIS SERVICE SHOULD NOT SHOW UP IN THE UI',
+        longDescription: 'It has the `status.removedFromBrokerCatalog` and should not be displayed.',
+      }
+    },
+    status: {
+      // This should not appear in the UI
+      removedFromBrokerCatalog: true
     }
   }
 };

--- a/bower.json
+++ b/bower.json
@@ -40,7 +40,7 @@
     "patternfly": ">=3.27.5 <4.0.0",
     "jquery": "~3.2.1",
     "lodash": "~4.17.4",
-    "origin-web-common": "~0.0.65",
+    "origin-web-common": "~0.0.66",
     "angular-schema-form-bootstrap": "^0.2.0"
   },
   "devDependencies": {

--- a/dist/origin-web-catalogs.js
+++ b/dist/origin-web-catalogs.js
@@ -632,36 +632,40 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             this.dataService = i, this.logger = s;
         }
         return e.prototype.getCatalogItems = function(e) {
-            var t = this, r = this.$q.defer(), n = {}, i = 0, s = 0, a = [], o = this.apiService.getPreferredVersion("clusterserviceclasses");
-            this.apiService.apiInfo(o) && (++i, this.dataService.list(o, {}).then(function(e) {
-                n.serviceClasses = e.by("metadata.name");
+            var t = this, r = this.$q.defer(), n = {}, s = 0, a = 0, o = [], c = this.apiService.getPreferredVersion("clusterserviceclasses");
+            this.apiService.apiInfo(c) && (++s, this.dataService.list(c, {}).then(function(e) {
+                n.serviceClasses = i.reject(e.by("metadata.name"), {
+                    status: {
+                        removedFromBrokerCatalog: !0
+                    }
+                });
             }, function() {
-                a.push("service classes");
+                o.push("service classes");
             }).finally(function() {
-                t.returnCatalogItems(r, n, ++s, i, a);
-            })), ++i;
-            var c = this.apiService.getPreferredVersion("imagestreams");
-            if (this.dataService.list(c, {
+                t.returnCatalogItems(r, n, ++a, s, o);
+            })), ++s;
+            var l = this.apiService.getPreferredVersion("imagestreams");
+            if (this.dataService.list(l, {
                 namespace: "openshift"
             }).then(function(e) {
                 n.imageStreams = e.by("metadata.name");
             }, function() {
-                a.push("builder images");
+                o.push("builder images");
             }).finally(function() {
-                t.returnCatalogItems(r, n, ++s, i, a);
+                t.returnCatalogItems(r, n, ++a, s, o);
             }), e) {
-                ++i;
-                var l = this.apiService.getPreferredVersion("templates");
-                this.dataService.list(l, {
+                ++s;
+                var d = this.apiService.getPreferredVersion("templates");
+                this.dataService.list(d, {
                     namespace: "openshift"
                 }, null, {
                     partialObjectMetadataList: !0
                 }).then(function(e) {
                     n.templates = e.by("metadata.name");
                 }, function() {
-                    a.push("templates");
+                    o.push("templates");
                 }).finally(function() {
-                    t.returnCatalogItems(r, n, ++s, i, a);
+                    t.returnCatalogItems(r, n, ++a, s, o);
                 });
             }
             return r.promise;
@@ -669,7 +673,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             var e = this.apiService.getPreferredVersion("clusterserviceplans");
             return this.apiService.apiInfo(e) ? this.dataService.list(e, {}) : this.$q.when(null);
         }, e.prototype.groupPlansByServiceClassName = function(e) {
-            return i.groupBy(e, "spec.serviceClassRef.name");
+            return i.groupBy(e, "spec.clusterServiceClassRef.name");
         }, e.prototype.getProjectCatalogItems = function(e, t, r, n) {
             var i = this;
             void 0 === t && (t = !0), void 0 === r && (r = !0), void 0 === n && (n = !1);
@@ -799,7 +803,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
         function e(e, t) {
             this.resource = e, this.catalogSrv = t, this.imageUrl = this.getImage(), this.iconClass = this.getIcon(), 
             this.name = this.getName(), this.description = this.getDescription(), this.longDescription = this.getLongDescription(), 
-            this.tags = this.getTags(), this.kind = "ServiceClass", this.vendor = this.getVendor(), 
+            this.tags = this.getTags(), this.kind = "ClusterServiceClass", this.vendor = this.getVendor(), 
             this.hidden = i.includes(this.tags, "hidden");
         }
         return e.prototype.getImage = function() {
@@ -916,7 +920,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
 }, function(e, t) {
     e.exports = '<div class="order-service">\n  <pf-wizard\n       title="{{$ctrl.imageStream.name}} {{$ctrl.istag.name}}"\n       hide-sidebar="true"\n       step-class="order-service-wizard-step"\n       wizard-ready="$ctrl.wizardReady"\n       next-title="$ctrl.nextTitle"\n       on-finish="$ctrl.closePanel()"\n       on-cancel="$ctrl.closePanel()"\n       wizard-done="$ctrl.wizardDone">\n    <pf-wizard-step ng-repeat="step in $ctrl.steps track by $index"\n         step-title="{{step.label}}"\n         wz-disabled="{{step.hidden}}"\n         allow-click-nav="step.allowClickNav"\n         next-enabled="step.valid && !$ctrl.updating"\n         prev-enabled="step.prevEnabled"\n         on-show="step.onShow"\n         step-id="{{step.id}}"\n         step-priority="{{$index}}">\n      <div class="wizard-pf-main-inner-shadow-covers">\n        <div class="order-service-config">\n          <div ng-include="step.view" class="wizard-pf-main-form-contents"></div>\n        </div>\n      </div>\n    </>\n  </>\n</div>\n';
 }, function(e, t) {
-    e.exports = '<div class="landing-search-area" ng-transclude="landingsearch"></div>\n<div class="landing">\n  <overlay-panel show-panel="$ctrl.orderingPanelVisible" handle-close="$ctrl.closeOrderingPanel">\n    <order-service\n        ng-if="$ctrl.selectedItem.resource.kind === \'ServiceClass\'"\n        base-project-url="{{$ctrl.baseProjectUrl}}"\n        service-class="$ctrl.selectedItem"\n        service-plans="$ctrl.servicePlansForItem"\n        handle-close="$ctrl.closeOrderingPanel">\n    </order-service>\n    <create-from-builder\n        ng-if="$ctrl.selectedItem.resource.kind === \'ImageStream\'"\n        base-project-url="{{$ctrl.baseProjectUrl}}"\n        image-stream="$ctrl.selectedItem"\n        handle-close="$ctrl.closeOrderingPanel">\n    </create-from-builder>\n  </overlay-panel>\n  <div class="landing-main-area">\n    <div class="landing-header-area" ng-transclude="landingheader"></div>\n    <div class="landing-body-area">\n      <div class="landing-body" ng-transclude="landingbody"></div>\n    </div>\n  </div>\n  <div class="landing-side-bar" ng-transclude="landingside"></div>\n</div>\n';
+    e.exports = '<div class="landing-search-area" ng-transclude="landingsearch"></div>\n<div class="landing">\n  <overlay-panel show-panel="$ctrl.orderingPanelVisible" handle-close="$ctrl.closeOrderingPanel">\n    <order-service\n        ng-if="$ctrl.selectedItem.resource.kind === \'ClusterServiceClass\'"\n        base-project-url="{{$ctrl.baseProjectUrl}}"\n        service-class="$ctrl.selectedItem"\n        service-plans="$ctrl.servicePlansForItem"\n        handle-close="$ctrl.closeOrderingPanel">\n    </order-service>\n    <create-from-builder\n        ng-if="$ctrl.selectedItem.resource.kind === \'ImageStream\'"\n        base-project-url="{{$ctrl.baseProjectUrl}}"\n        image-stream="$ctrl.selectedItem"\n        handle-close="$ctrl.closeOrderingPanel">\n    </create-from-builder>\n  </overlay-panel>\n  <div class="landing-main-area">\n    <div class="landing-header-area" ng-transclude="landingheader"></div>\n    <div class="landing-body-area">\n      <div class="landing-body" ng-transclude="landingbody"></div>\n    </div>\n  </div>\n  <div class="landing-side-bar" ng-transclude="landingside"></div>\n</div>\n';
 }, function(e, t) {
     e.exports = '<div class="order-service">\n  <pf-wizard\n       title="{{$ctrl.serviceName}}"\n       hide-sidebar="true"\n       step-class="order-service-wizard-step"\n       wizard-ready="$ctrl.wizardReady"\n       next-title="$ctrl.nextTitle"\n       on-finish="$ctrl.closePanel()"\n       on-cancel="$ctrl.closePanel()"\n       wizard-done="$ctrl.wizardDone">\n    <pf-wizard-step ng-repeat="step in $ctrl.steps track by step.id"\n         step-title="{{step.label}}"\n         wz-disabled="{{step.hidden}}"\n         allow-click-nav="step.allowClickNav"\n         next-enabled="step.valid && !$ctrl.updating"\n         prev-enabled="step.prevEnabled"\n         on-show="step.onShow"\n         step-id="{{step.id}}"\n         step-priority="{{$index}}">\n      <div class="wizard-pf-main-inner-shadow-covers">\n        <div ng-include="step.view" class="wizard-pf-main-form-contents"></div>\n      </div>\n    </pf-wizard-step>\n  </pf-wizard>\n</div>\n';
 }, function(e, t) {
@@ -1327,7 +1331,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
 }, function(e, t, r) {
     "use strict";
     t.__esModule = !0;
-    var n = function() {
+    var n = r(0), i = function() {
         function e(e, t, r) {
             var n = this;
             this.ctrl = this, this.closeOrderingPanel = function() {
@@ -1337,20 +1341,24 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
         return e.prototype.$onInit = function() {
             var e = this;
             this.ctrl.searchText = "", this.ctrl.orderingPanelVisible = !1, this.Catalog.getServicePlans().then(function(t) {
-                t && (t = t.by("metadata.name"), e.plansByServiceClassName = e.Catalog.groupPlansByServiceClassName(t));
+                t && (t = n.reject(t.by("metadata.name"), {
+                    status: {
+                        removedFromBrokerCatalog: !0
+                    }
+                }), e.plansByServiceClassName = e.Catalog.groupPlansByServiceClassName(t));
             }), this.$scope.$on("open-overlay-panel", function(t, r) {
                 if (e.ctrl.servicePlansForItem = null, "Template" === r.kind) {
                     var n = e.ctrl.onTemplateSelected();
                     return void (n && n(r.resource));
                 }
-                "ServiceClass" === r.kind && (e.ctrl.servicePlansForItem = e.plansByServiceClassName[r.resource.metadata.name]), 
+                "ClusterServiceClass" === r.kind && (e.ctrl.servicePlansForItem = e.plansByServiceClassName[r.resource.metadata.name]), 
                 e.ctrl.selectedItem = r, e.ctrl.orderingPanelVisible = !0;
             });
         }, e.prototype.$onDestroy = function() {
             this.ctrl.orderingPanelVisible && this.closeOrderingPanel();
         }, e;
     }();
-    n.$inject = [ "$scope", "Catalog", "RecentlyViewedServiceItems" ], t.LandingPageController = n;
+    i.$inject = [ "$scope", "Catalog", "RecentlyViewedServiceItems" ], t.LandingPageController = i;
 }, function(e, t, r) {
     "use strict";
     t.__esModule = !0;
@@ -1545,10 +1553,10 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             return i.omitBy(this.ctrl.parameterData, function(e) {
                 return "" === e;
             });
-        }, e.prototype.getExternalServiceClassName = function() {
+        }, e.prototype.getExternalClusterServiceClassName = function() {
             return i.get(this, "ctrl.serviceClass.resource.spec.externalName");
         }, e.prototype.generateSecretName = function() {
-            var e = 5, t = i.truncate(this.getExternalServiceClassName() + "-parameters", {
+            var e = 5, t = i.truncate(this.getExternalClusterServiceClassName() + "-parameters", {
                 length: this.DNS1123_SUBDOMAIN_VALIDATION.maxlength - e - 1,
                 omission: ""
             });
@@ -1574,16 +1582,16 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
                 }
             };
         }, e.prototype.makeServiceInstance = function(e) {
-            var t = this.getExternalServiceClassName(), r = {
+            var t = this.getExternalClusterServiceClassName(), r = {
                 kind: "ServiceInstance",
-                apiVersion: "servicecatalog.k8s.io/v1alpha1",
+                apiVersion: "servicecatalog.k8s.io/v1beta1",
                 metadata: {
                     namespace: this.ctrl.selectedProject.metadata.name,
                     generateName: t + "-"
                 },
                 spec: {
-                    externalServiceClassName: t,
-                    externalServicePlanName: this.ctrl.selectedPlan.spec.externalName
+                    externalClusterServiceClassName: t,
+                    externalClusterServicePlanName: this.ctrl.selectedPlan.spec.externalName
                 }
             };
             return e && (r.spec.parametersFrom = [ {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7985,9 +7985,9 @@
       "dev": true
     },
     "origin-web-common": {
-      "version": "0.0.64",
-      "resolved": "https://registry.npmjs.org/origin-web-common/-/origin-web-common-0.0.64.tgz",
-      "integrity": "sha512-7jfOpvjZ59C3ZRW3L7rUi1gt+7JWBnjT/Kbg8L53g0UW1Bzfq4Nuc/PwjspvM9V7cfmJ+4JvXtTfpWEaQSHd6Q==",
+      "version": "0.0.66",
+      "resolved": "https://registry.npmjs.org/origin-web-common/-/origin-web-common-0.0.66.tgz",
+      "integrity": "sha512-KFI0TUfROd2g2G0evIKwyfBZFVO8A+5E3nSXuxzBH5p8G/bHfBpqzRst6nDoQCp0HKqHP1+u95jKPle+BOusJA==",
       "requires": {
         "angular": "1.5.11"
       }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "bootstrap": "^3.3.6",
     "font-awesome": "~4.7.0",
     "jquery": "3.2.1",
-    "origin-web-common": "~0.0.65",
+    "origin-web-common": "~0.0.66",
     "paper-css": "^0.1.2",
     "patternfly": ">=3.27.5 <4.0.0",
     "urijs": "1.18.0"

--- a/src/components/landing-page/landing-page.controller.ts
+++ b/src/components/landing-page/landing-page.controller.ts
@@ -1,4 +1,5 @@
 import * as angular from 'angular';
+import * as _ from 'lodash';
 
 export class LandingPageController implements angular.IController {
   static $inject = ['$scope', 'Catalog', 'RecentlyViewedServiceItems'];
@@ -25,7 +26,11 @@ export class LandingPageController implements angular.IController {
         return;
       }
 
-      plans = plans.by('metadata.name');
+      plans = _.reject(plans.by("metadata.name"), {
+        status: {
+          removedFromBrokerCatalog: true
+        }
+      });
       this.plansByServiceClassName = this.Catalog.groupPlansByServiceClassName(plans);
     });
 
@@ -39,7 +44,7 @@ export class LandingPageController implements angular.IController {
         return;
       }
 
-      if (item.kind === 'ServiceClass') {
+      if (item.kind === 'ClusterServiceClass') {
         this.ctrl.servicePlansForItem = this.plansByServiceClassName[item.resource.metadata.name];
       }
 

--- a/src/components/landing-page/landing-page.html
+++ b/src/components/landing-page/landing-page.html
@@ -2,7 +2,7 @@
 <div class="landing">
   <overlay-panel show-panel="$ctrl.orderingPanelVisible" handle-close="$ctrl.closeOrderingPanel">
     <order-service
-        ng-if="$ctrl.selectedItem.resource.kind === 'ServiceClass'"
+        ng-if="$ctrl.selectedItem.resource.kind === 'ClusterServiceClass'"
         base-project-url="{{$ctrl.baseProjectUrl}}"
         service-class="$ctrl.selectedItem"
         service-plans="$ctrl.servicePlansForItem"

--- a/src/components/order-service/order-service.controller.ts
+++ b/src/components/order-service/order-service.controller.ts
@@ -413,14 +413,14 @@ export class OrderServiceController implements angular.IController {
     });
   }
 
-  private getExternalServiceClassName(): string {
+  private getExternalClusterServiceClassName(): string {
     return _.get(this, 'ctrl.serviceClass.resource.spec.externalName') as string;
   };
 
   private generateSecretName(): string {
     let generateNameLength = 5;
     // Truncate the class name if it's too long to append the generated name suffix.
-    let secretNamePrefix = _.truncate(this.getExternalServiceClassName() + '-parameters', {
+    let secretNamePrefix = _.truncate(this.getExternalClusterServiceClassName() + '-parameters', {
       // `generateNameLength - 1` because we append a '-' and then a 5 char generated suffix
       length: this.DNS1123_SUBDOMAIN_VALIDATION.maxlength - generateNameLength - 1,
       omission: ''
@@ -454,17 +454,17 @@ export class OrderServiceController implements angular.IController {
   }
 
   private makeServiceInstance(secretName: string) {
-    let externalServiceClassName = this.getExternalServiceClassName();
+    let externalClusterServiceClassName = this.getExternalClusterServiceClassName();
     let serviceInstance: any = {
       kind: 'ServiceInstance',
-      apiVersion: 'servicecatalog.k8s.io/v1alpha1',
+      apiVersion: 'servicecatalog.k8s.io/v1beta1',
       metadata: {
         namespace: this.ctrl.selectedProject.metadata.name,
-        generateName: externalServiceClassName + '-'
+        generateName: externalClusterServiceClassName + '-'
        },
        spec: {
-         externalServiceClassName: externalServiceClassName,
-         externalServicePlanName: this.ctrl.selectedPlan.spec.externalName
+         externalClusterServiceClassName: externalClusterServiceClassName,
+         externalClusterServicePlanName: this.ctrl.selectedPlan.spec.externalName
        }
     };
 

--- a/src/services/catalog.service.ts
+++ b/src/services/catalog.service.ts
@@ -33,7 +33,11 @@ export class CatalogService { static $inject = ['$filter', '$q', 'Constants', 'A
     if (this.apiService.apiInfo(serviceClassesVersion)) {
       ++totalNumPromises;
       this.dataService.list(serviceClassesVersion, {}).then( (resources: any) => {
-        catalogItems.serviceClasses = resources.by("metadata.name");
+        catalogItems.serviceClasses = _.reject(resources.by("metadata.name"), {
+          status: {
+            removedFromBrokerCatalog: true
+          }
+        });
       }, () => {
         errorMsg.push('service classes');
       }).finally(() => {
@@ -77,7 +81,7 @@ export class CatalogService { static $inject = ['$filter', '$q', 'Constants', 'A
   }
 
   public groupPlansByServiceClassName(plans: any) : any {
-    return _.groupBy(plans, 'spec.serviceClassRef.name');
+    return _.groupBy(plans, 'spec.clusterServiceClassRef.name');
   }
 
   public getProjectCatalogItems(projectName: string, includeImages: boolean = true, includeTemplates: boolean = true, partialObjectMetadataList: boolean = false ) {
@@ -351,7 +355,7 @@ export class ServiceItem implements IServiceItem {
     this.description = this.getDescription();
     this.longDescription = this.getLongDescription();
     this.tags = this.getTags();
-    this.kind = "ServiceClass";
+    this.kind = "ClusterServiceClass";
     this.vendor = this.getVendor();
     this.hidden = _.includes(this.tags, 'hidden');
   }

--- a/test/services-view.spec.ts
+++ b/test/services-view.spec.ts
@@ -33,7 +33,7 @@ describe('servicesView', () => {
   });
 
   beforeEach(() => {
-    services = angular.copy(servicesData);
+    services = angular.copy(_.reject(servicesData, { status: { removedFromBrokerCatalog: true } }));
     images = angular.copy(imagesData);
     catalogItems = Catalog.convertToServiceItems(services, images);
   });
@@ -148,7 +148,7 @@ describe('servicesView', () => {
 
     services = {
       "mycat-database": {
-        kind: 'ServiceClass',
+        kind: 'ClusterServiceClass',
         "metadata": {
           "name": "mycat-database",
           "uid": "10",
@@ -161,7 +161,7 @@ describe('servicesView', () => {
         }
       },
       "mycat-other": {
-        kind: 'ServiceClass',
+        kind: 'ClusterServiceClass',
         "metadata": {
           "name": "mycat-other",
           "uid": "11",
@@ -213,7 +213,7 @@ describe('servicesView', () => {
 
     services = {
       "mycat-database": {
-        kind: 'ServiceClass',
+        kind: 'ClusterServiceClass',
         "metadata": {
           "name": "mycat-database",
           "uid": "10",


### PR DESCRIPTION
Requires https://github.com/openshift/origin-web-common/pull/223
Updates origin-web-common to 0.0.66

* Cluster prefix for service classes and plans
* ServiceInstanceCredential -> ServiceBinding
* check removedFromBrokerCatalog

TODO:

- [x] Write test for removedFromBrokerCatalog

cc @jeff-phillips-18 