### PR TITLE
Fix missing service class description

### DIFF
--- a/dist/origin-web-catalogs.js
+++ b/dist/origin-web-catalogs.js
@@ -815,7 +815,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
         }, e.prototype.getName = function() {
             return i.get(this.resource, "spec.externalMetadata.displayName") || this.resource.metadata.name;
         }, e.prototype.getDescription = function() {
-            return i.get(this.resource, "description") || "";
+            return i.get(this.resource, "spec.description") || "";
         }, e.prototype.getLongDescription = function() {
             return i.get(this.resource, "spec.externalMetadata.longDescription") || "";
         }, e.prototype.getTags = function() {

--- a/src/services/catalog.service.ts
+++ b/src/services/catalog.service.ts
@@ -378,7 +378,7 @@ export class ServiceItem implements IServiceItem {
   }
 
   private getDescription(): string {
-    return _.get(this.resource, 'description') as string || '';
+    return _.get(this.resource, 'spec.description') as string || '';
   }
 
   private getLongDescription(): string {


### PR DESCRIPTION
The service class description is missing from our dialogs after the API changes. I missed this because long-description was showing up.

@rhamilto FYI