### PR TITLE
Fix to scroll when overlay panel is too tall for viewport

### DIFF
--- a/dist/less/overlay-panel.less
+++ b/dist/less/overlay-panel.less
@@ -115,6 +115,8 @@ body.overlay-open {
 .catalogs-overlay-panel-wrapper {
   bottom: 0;
   left: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
   position: fixed;
   right: 0;
   top: 0;

--- a/dist/origin-web-catalogs.css
+++ b/dist/origin-web-catalogs.css
@@ -539,6 +539,8 @@ body.overlay-open .landing-side-bar {
 .catalogs-overlay-panel-wrapper {
   bottom: 0;
   left: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
   position: fixed;
   right: 0;
   top: 0;

--- a/src/styles/overlay-panel.less
+++ b/src/styles/overlay-panel.less
@@ -115,6 +115,8 @@ body.overlay-open {
 .catalogs-overlay-panel-wrapper {
   bottom: 0;
   left: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
   position: fixed;
   right: 0;
   top: 0;


### PR DESCRIPTION
Simple fix for https://github.com/openshift/origin-web-console/issues/2095