### PR TITLE
Fixing bug where SVG images were clipping in IE11

### DIFF
--- a/dist/less/services-view.less
+++ b/dist/less/services-view.less
@@ -86,7 +86,7 @@ services-view,
       }
       // so that SVGs are sized correctly in Safari and IE
       img[src$=".svg"] {
-        height: 50px;
+        width: 50px;
       }
     }
 

--- a/dist/origin-web-catalogs.css
+++ b/dist/origin-web-catalogs.css
@@ -1018,7 +1018,7 @@ services-view .vendor-info-icon,
   z-index: 1;
 }
 .services-view .services-item .services-item-icon img[src$=".svg"] {
-  height: 50px;
+  width: 50px;
 }
 .services-view .services-item .icon-ruby,
 .services-view .services-item .fa-question {

--- a/src/styles/services-view.less
+++ b/src/styles/services-view.less
@@ -86,7 +86,7 @@ services-view,
       }
       // so that SVGs are sized correctly in Safari and IE
       img[src$=".svg"] {
-        height: 50px;
+        width: 50px;
       }
     }
 


### PR DESCRIPTION
In the cases where SVG images were wider than they were tall, setting a height didn't work.  Changing to width does work since all of our SVGs are wider than they are tall or are square.  If we end up with SVGs that are taller than they are wide, we may end up with this bug again.

Supports https://github.com/openshift/origin-web-console/issues/2278