### PR TITLE
Don't load service classes and plans if no pod presets

### DIFF
--- a/dist/origin-web-catalogs.js
+++ b/dist/origin-web-catalogs.js
@@ -1205,7 +1205,8 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             this.ctrl.serviceToBind = null, this.ctrl.updating = !1, this.ctrl.serviceInstances = [], 
             this.selectedProjectWatch = this.$scope.$watch(function() {
                 return e.ctrl.selectedProject;
-            }, this.onProjectUpdate), this.getServiceClassesAndPlans(), this.instancesSupported = !!this.APIService.apiInfo(this.APIService.getPreferredVersion("serviceinstances"));
+            }, this.onProjectUpdate), this.ctrl.showPodPresets ? (this.getServiceClassesAndPlans(), 
+            this.instancesSupported = !!this.APIService.apiInfo(this.APIService.getPreferredVersion("serviceinstances"))) : this.instancesSupported = !1;
         }, e.prototype.closePanel = function() {
             n.isFunction(this.ctrl.handleClose) && this.ctrl.handleClose();
         }, e.prototype.$onDestroy = function() {
@@ -1262,7 +1263,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
                 }), this.ctrl.serviceInstances = e;
             }
         }, e.prototype.updateBindability = function() {
-            this.ctrl.wizardDone || (this.bindStep.hidden = i.size(this.ctrl.serviceInstances) < 1, 
+            !this.ctrl.wizardDone && this.ctrl.showPodPresets && (this.bindStep.hidden = i.size(this.ctrl.serviceInstances) < 1, 
             this.ctrl.serviceToBind = null, this.bindStep.hidden ? this.ctrl.nextTitle = "Create" : this.ctrl.nextTitle = "Next >");
         }, e.prototype.isNewProject = function() {
             return !i.has(this.ctrl.selectedProject, "metadata.uid");

--- a/src/components/create-from-builder/create-from-builder.controller.ts
+++ b/src/components/create-from-builder/create-from-builder.controller.ts
@@ -121,8 +121,13 @@ export class CreateFromBuilderController implements angular.IController {
       },
       this.onProjectUpdate
     );
-    this.getServiceClassesAndPlans();
-    this.instancesSupported = !!this.APIService.apiInfo(this.APIService.getPreferredVersion('serviceinstances'));
+    if (this.ctrl.showPodPresets) {
+      // FIXME: We should not need to request these again.
+      this.getServiceClassesAndPlans();
+      this.instancesSupported = !!this.APIService.apiInfo(this.APIService.getPreferredVersion('serviceinstances'));
+    } else {
+      this.instancesSupported = false;
+    }
   }
 
   public closePanel() {
@@ -291,7 +296,7 @@ export class CreateFromBuilderController implements angular.IController {
   };
 
   private updateBindability() {
-    if (this.ctrl.wizardDone) {
+    if (this.ctrl.wizardDone || !this.ctrl.showPodPresets) {
       return;
     }
     this.bindStep.hidden = _.size(this.ctrl.serviceInstances) < 1;


### PR DESCRIPTION
Don't load service classes and plans in the builder dialog if there are no pod presets.

Fixes #511