### PR TITLE
Make recently view item logos have max-height and max-width of 32px

### DIFF
--- a/dist/less/projects-summary.less
+++ b/dist/less/projects-summary.less
@@ -141,8 +141,8 @@
           width: 60px;
         }
         img {
-          max-height: 30%;
-          max-width: 30%;
+          max-height: 32px;
+          max-width: 32px;
         }
       }
       .services-item-name {

--- a/dist/origin-web-catalogs.css
+++ b/dist/origin-web-catalogs.css
@@ -734,8 +734,8 @@ body.overlay-open .landing-side-bar {
   width: 60px;
 }
 .catalog-projects-summary-panel .services-view .services-item .services-item-icon img {
-  max-height: 30%;
-  max-width: 30%;
+  max-height: 32px;
+  max-width: 32px;
 }
 .catalog-projects-summary-panel .services-view .services-item .services-item-name {
   color: #fff;

--- a/src/styles/projects-summary.less
+++ b/src/styles/projects-summary.less
@@ -141,8 +141,8 @@
           width: 60px;
         }
         img {
-          max-height: 30%;
-          max-width: 30%;
+          max-height: 32px;
+          max-width: 32px;
         }
       }
       .services-item-name {


### PR DESCRIPTION
Fixes https://github.com/openshift/origin-web-catalog/issues/506

<img width="728" alt="screen shot 2017-10-20 at 12 02 04 pm" src="https://user-images.githubusercontent.com/1874151/31831042-0d913610-b590-11e7-9709-9bbf3885dd4e.png">
