### PR TITLE
Fix planUpdatable check

### DIFF
--- a/dist/origin-web-catalogs.js
+++ b/dist/origin-web-catalogs.js
@@ -2158,7 +2158,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
                 id: "plans",
                 label: "Plan",
                 view: "update-service/update-service-plans.html",
-                hidden: i.get(this.ctrl.serviceClass, "spec.planUpdatable", !1) || i.size(this.ctrl.servicePlans) < 2,
+                hidden: !i.get(this.ctrl.serviceClass, "spec.planUpdatable", !1) || i.size(this.ctrl.servicePlans) < 2,
                 allowed: !0,
                 valid: !0,
                 allowClickNav: !0,

--- a/src/components/update-service/update-service.controller.ts
+++ b/src/components/update-service/update-service.controller.ts
@@ -67,7 +67,7 @@ export class UpdateServiceController implements angular.IController {
       id: 'plans',
       label: 'Plan',
       view: 'update-service/update-service-plans.html',
-      hidden: _.get(this.ctrl.serviceClass, 'spec.planUpdatable', false) || _.size(this.ctrl.servicePlans) < 2,
+      hidden: !_.get(this.ctrl.serviceClass, 'spec.planUpdatable', false) || _.size(this.ctrl.servicePlans) < 2,
       allowed: true,
       valid: true,
       allowClickNav: true,


### PR DESCRIPTION
The logic was reversed deciding to hide the plans step when updating a service instance.

See https://github.com/openshift/origin-web-console/issues/2350