### PR TITLE
Avoid errors when an image dependency appears twice

### DIFF
--- a/dist/origin-web-catalogs.js
+++ b/dist/origin-web-catalogs.js
@@ -1539,10 +1539,11 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             this.ctrl.longDescription = this.ctrl.serviceClass.longDescription, this.ctrl.docUrl = i.get(this.ctrl.serviceClass, "resource.spec.externalMetadata.documentationUrl"), 
             this.ctrl.supportUrl = i.get(this.ctrl.serviceClass, "resource.spec.externalMetadata.supportUrl");
             var t = i.get(this.ctrl.serviceClass, "resource.spec.externalMetadata.dependencies");
-            i.isArray(t) && (this.ctrl.imageDependencies = i.filter(t, i.isString)), this.ctrl.noProjectsCantCreate = !1, 
-            this.ctrl.applications = [], this.ctrl.parameterData = {}, this.ctrl.bindParameterData = {}, 
-            this.ctrl.forms = {}, this.ctrl.appToBind = null, this.ctrl.configStepValid = !0, 
-            this.ctrl.multipleServicePlans = i.size(this.ctrl.servicePlans) > 1, this.infoStep = {
+            i.isArray(t) && (this.ctrl.imageDependencies = i.uniq(i.filter(t, i.isString))), 
+            this.ctrl.noProjectsCantCreate = !1, this.ctrl.applications = [], this.ctrl.parameterData = {}, 
+            this.ctrl.bindParameterData = {}, this.ctrl.forms = {}, this.ctrl.appToBind = null, 
+            this.ctrl.configStepValid = !0, this.ctrl.multipleServicePlans = i.size(this.ctrl.servicePlans) > 1, 
+            this.infoStep = {
                 id: "info",
                 label: "Information",
                 view: "order-service/order-service-info.html",

--- a/src/components/order-service/order-service.controller.ts
+++ b/src/components/order-service/order-service.controller.ts
@@ -70,7 +70,8 @@ export class OrderServiceController implements angular.IController {
     // that is an array of images names.
     let dependencies = _.get(this.ctrl.serviceClass, 'resource.spec.externalMetadata.dependencies');
     if (_.isArray(dependencies)) {
-      this.ctrl.imageDependencies = _.filter(dependencies, _.isString);
+      // Take out any duplicates to avoid duplicates in a repeater error.
+      this.ctrl.imageDependencies = _.uniq(_.filter(dependencies, _.isString));
     }
 
     this.ctrl.noProjectsCantCreate = false;


### PR DESCRIPTION
Avoid `ng-repeat` errors by filtering duplicates from the dependencies array.

Fixes #528

![openshift catalog components 2017-10-24 16-51-18](https://user-images.githubusercontent.com/1167259/31967322-929dd806-b8db-11e7-8b0e-df2c103ddae2.png)
