### PR TITLE
Improve display of provision call failure message

### DIFF
--- a/src/components/create-from-builder/create-from-builder-results.html
+++ b/src/components/create-from-builder/create-from-builder-results.html
@@ -36,27 +36,10 @@
     </p>
   </div>
   <div class="results-failure" ng-if="$ctrl.error">
-    <div class="results-status">
-      <span class="pficon pficon-error-circle-o text-danger" aria-hidden="true"></span>
-      <div class="results-message">
-        <h3>
-          <strong>{{$ctrl.name}}</strong> failed to create in <strong>{{$ctrl.selectedProject | displayName}}</strong>.
-        </h3>
-      </div>
-    </div>
-    <div class="sub-title">
-      <span ng-if="$ctrl.error.data.message">
-        {{$ctrl.error.data.message | upperFirst}}
-      </span>
-      <span ng-if="!$ctrl.error.data.message">
-        An error occurred creating the application.
-      </span>
-    </div>
-    <!-- TODO: Improve error message presentation -->
-    <ul ng-if="$ctrl.error.failure.length" class="failure-messages">
-      <li ng-repeat="failure in $ctrl.error.failure">
-        {{failure.data.message}}
-      </li>
-    </ul>
+    <result-error error="$ctrl.error" 
+                  action-type="create"
+                  service-name="$ctrl.name"
+                  project-name="$ctrl.selectedProject | displayName">
+    </result-error>
   </div>
 </div>

--- a/src/components/order-service/order-service-results.html
+++ b/src/components/order-service/order-service-results.html
@@ -17,20 +17,13 @@
       <p><a ng-href="{{$ctrl.selectedProject | projectUrl : $ctrl.baseProjectUrl}}">Continue to the project overview</a> to check the status of your service.</p>
     </div>
   </div>
+
   <div class="results-failure" ng-if="$ctrl.error">
-    <div class="results-status">
-      <span class="pficon pficon-error-circle-o text-danger" aria-hidden="true"></span>
-      <span class="sr-only">Error</span>
-      <div class="results-message">
-        <h3>
-          <strong>{{$ctrl.serviceClass.name}}</strong> failed to provision in <strong>{{$ctrl.projectDisplayName}}</strong>.
-        </h3>
-      </div>
-    </div>
-    <div class="sub-title">
-      <span ng-if="$ctrl.error.message" class="error-message">{{$ctrl.error.message}}</span>
-      <span ng-if="!$ctrl.error.message" class="error-message">An error occurred provisioning the service.</span>
-    </div>
+    <result-error error="$ctrl.error" 
+                  action-type="provision"
+                  service-name="$ctrl.serviceClass.name"
+                  project-name="$ctrl.projectDisplayName">
+    </result-error>
   </div>
   <div ng-if="$ctrl.orderComplete">
     <div class="results-status">

--- a/src/components/order-service/order-service.controller.ts
+++ b/src/components/order-service/order-service.controller.ts
@@ -277,7 +277,7 @@ export class OrderServiceController implements angular.IController {
           this.ctrl.projectDisplayName = this.$filter('displayName')(project);
           this.createService();
         }, (result: any) => {
-          this.ctrl.error = result.data;
+          this.ctrl.error = this.$filter('formatError')(result.data);
         });
     } else {
       this.ctrl.projectDisplayName = this.$filter('displayName')(this.ctrl.selectedProject);
@@ -305,7 +305,7 @@ export class OrderServiceController implements angular.IController {
       if (secretName) {
         let secret = this.BindingService.makeParametersSecret(secretName, parameters, serviceInstance);
         this.DataService.create('secrets', null, secret, context).then(_.noop, (e: any) => {
-          this.ctrl.error = _.get(e, 'data');
+          this.ctrl.error = this.$filter('formatError')(_.get(e, 'data'));
         });
       }
 
@@ -313,7 +313,7 @@ export class OrderServiceController implements angular.IController {
         this.bindService();
       }
     }, (e: any) => {
-      this.ctrl.error = _.get(e, 'data');
+      this.ctrl.error = this.$filter('formatError')(_.get(e, 'data'));
     });
   }
 
@@ -473,7 +473,7 @@ export class OrderServiceController implements angular.IController {
       var readyCondition: any = _.find(conditions, {type: 'Ready'});
 
       this.ctrl.orderComplete = readyCondition && readyCondition.status === 'True';
-      this.ctrl.error = _.find(conditions, {type: 'Failed', status: 'True'});
+      this.ctrl.error = this.$filter('formatError')(_.find(conditions, {type: 'Failed', status: 'True'}));
     }));
   };
 }

--- a/src/components/result-error/result-error.component.ts
+++ b/src/components/result-error/result-error.component.ts
@@ -1,0 +1,10 @@
+
+export const resultError: angular.IComponentOptions = {
+  bindings: {
+    error: '=',
+    actionType: '@',
+    serviceName: '=',
+    projectName: '='
+  },
+  template: require('./result-error.html'),
+};

--- a/src/components/result-error/result-error.html
+++ b/src/components/result-error/result-error.html
@@ -1,0 +1,22 @@
+<div class="results-status">
+  <span class="pficon pficon-error-circle-o text-danger" aria-hidden="true"></span>
+  <span class="sr-only">Error</span>
+  <div class="results-message">
+    <h3>
+      <strong>{{$ctrl.serviceName}}</strong> failed to {{$ctrl.actionType}} in <strong>{{$ctrl.projectName}}</strong>.
+    </h3>
+  </div>
+</div>
+<div class="sub-title">
+  <span ng-if="$ctrl.error.data.message">
+    {{$ctrl.error.data.message | upperFirst}}
+  </span>
+  <span ng-if="!$ctrl.error.data.message">
+    An error occurred creating the application.
+  </span>
+</div>
+<ul ng-if="$ctrl.error.failure.length" class="failure-messages">
+  <li ng-repeat="failure in $ctrl.error.failure">
+    {{failure.data.message}}
+  </li>
+</ul>

--- a/src/filters/formatError.ts
+++ b/src/filters/formatError.ts
@@ -1,0 +1,29 @@
+import * as _ from 'lodash';
+
+export function formatErrorFilter () {
+
+  return function(error: any) {
+    if (!error) {
+      return;
+    }
+    var setMessagefailures = _.spread(function(message: any, failure: any) {
+      _.extend(error, {
+        data: {
+          message: message
+        }
+      });
+      var failures = [];
+      _.each(_.split(failure, "\n"), function(message: any) {
+        failures.push({
+          data: {
+            message: message
+          }
+        });
+      });
+      error.failure = failures;
+    });
+    setMessagefailures(_.split(error.message, ":", 2));
+
+    return error;
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ require('./constants');
 
 
 // Filters
+import {formatErrorFilter} from './filters/formatError';
 import {escapeRegExpFilter} from './filters/escapeRegExp';
 import {projectUrlFilter} from './filters/projectUrl';
 import {secretUrlFilter} from './filters/secretUrl';
@@ -26,6 +27,7 @@ import {selectProject} from './components/select-project/select-project.componen
 import {servicesView} from './components/services-view/services-view.component';
 import {updateService} from './components/update-service/update-service.component';
 import {RecentlyViewedServiceItems} from './services/recently-viewed-service-items.service';
+import {resultError} from './components/result-error/result-error.component';
 import {catalogFilter} from './components/catalog-filter/catalog-filter.component';
 
 export const webCatalog: string = 'webCatalog';
@@ -38,6 +40,7 @@ angular
   .filter('escapeRegExp', escapeRegExpFilter)
   .filter('projectUrl', projectUrlFilter)
   .filter('secretUrl', secretUrlFilter)
+  .filter('formatError', formatErrorFilter)
   .component('catalogParameters', catalogParameters)
   .component('catalogSearch', catalogSearch)
   .component('createFromBuilder', createFromBuilder)
@@ -49,6 +52,7 @@ angular
   .component('selectPlan', selectPlan)
   .component('selectProject', selectProject)
   .component('servicesView', servicesView)
+  .component('resultError', resultError)
   .component('updateService', updateService)
   .component('catalogFilter', catalogFilter)
   .run(['$templateCache', function($templateCache: any) {


### PR DESCRIPTION
When creating a service that already exists we are not formatting the failure message:
![failure2](https://user-images.githubusercontent.com/1668218/32234946-6510d806-be5e-11e7-80df-46affeb3e500.png)

So I've reused the format that we are using in [create-from-builder-results.html](https://github.com/openshift/origin-web-catalog/blob/master/src/components/create-from-builder/create-from-builder-results.html#L47-L60) and created a new `result-error` component.
Unfortunately there is a difference between how those two error types (one from `create-from-builder.controller.ts` and the second from order-service.ts) are structured, since one is returned from the origin and the other one from service-catalog. So I've created `formatError` filter which  I'm using in the *order-service.controller.ts* which parses the error message into the same format as the error from the `create-from-builder.controller.ts`.

Formatted error now looks like:
![failure](https://user-images.githubusercontent.com/1668218/32268835-d728b908-bef0-11e7-9f87-795a523c50ea.png)


@spadgett @rhamilto PTAL