### PR TITLE
Fall back to external name when no display name is set

### DIFF
--- a/app/mockServices/mockData/services.ts
+++ b/app/mockServices/mockData/services.ts
@@ -123,15 +123,16 @@ export const servicesData = {
   "test-serviceclass-other": {
     kind: 'ClusterServiceClass',
     metadata: {
-      name: "test-serviceclass-other",
+      name: "40c9e163-bffe-11e7-a324-f2cad19b6969",
       uid: "8",
     },
     spec: {
       bindable: true,
       description: 'BUILDS SOURCE CODE',
       tags: ['fooBar'],
+      // Test that we correctly fall back to external name when no display name.
+      externalName: 'test-service-class-other',
       externalMetadata: {
-        displayName: 'Test ServiceClass Other',
         longDescription: 'some other service',
         'console.openshift.io/iconClass': 'fa fa-question'
       }

--- a/dist/origin-web-catalogs.js
+++ b/dist/origin-web-catalogs.js
@@ -877,7 +877,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             var e = i.get(this.resource, [ "spec", "externalMetadata", "console.openshift.io/iconClass" ]) || "fa fa-clone";
             return e = -1 !== e.indexOf("icon-") ? "font-icon " + e : e;
         }, e.prototype.getName = function() {
-            return i.get(this.resource, "spec.externalMetadata.displayName") || this.resource.metadata.name;
+            return i.get(this.resource, "spec.externalMetadata.displayName") || i.get(this.resource, "spec.externalName") || this.resource.metadata.name;
         }, e.prototype.getDescription = function() {
             return i.get(this.resource, "spec.description") || "";
         }, e.prototype.getLongDescription = function() {

--- a/src/services/catalog.service.ts
+++ b/src/services/catalog.service.ts
@@ -398,7 +398,7 @@ export class ServiceItem implements IServiceItem {
   }
 
   private getName(): string {
-    return _.get(this.resource, 'spec.externalMetadata.displayName') || this.resource.metadata.name;
+    return _.get(this.resource, 'spec.externalMetadata.displayName') || _.get(this.resource, 'spec.externalName') || this.resource.metadata.name;
   }
 
   private getDescription(): string {

--- a/test/services-view.spec.ts
+++ b/test/services-view.spec.ts
@@ -440,4 +440,31 @@ describe('servicesView', () => {
     expect(vendorFilters.length).toBe(4);
     expect(jQuery(vendorFilters[2]).text().trim()).toBe('Vendor B, Inc.');
   });
+
+  it("should fall back to external name when no display name", () => {
+    services = {
+      "40c9e163-bffe-11e7-a324-f2cad19b6969": {
+        kind: "ClusterServiceClass",
+        metadata: {
+          name: "40c9e163-bffe-11e7-a324-f2cad19b6969",
+          uid: "724e409d-bfee-11e7-a324-f2cad19b6969"
+        },
+        spec: {
+          externalName: 'my-service-class'
+        }
+      }
+    };
+
+    images = {};
+
+    catalogItems = Catalog.convertToServiceItems(services, images);
+
+    createServiceView();
+
+    var element = componentTest.rawElement;
+
+    var items = jQuery(element).find('.services-item-name');
+    expect(items.length).toBe(1);
+    expect(jQuery(items[0]).text().trim()).toBe('my-service-class');
+  });
 });


### PR DESCRIPTION
For service classes, use the external name when there's no display name set.
This prevents the internal UID from being shown in the UI.

https://github.com/kubernetes-incubator/service-catalog/blob/master/pkg/apis/servicecatalog/v1beta1/types.go#L244-L246

Fixes:

![image](https://user-images.githubusercontent.com/1167259/32376937-99e38fae-c07c-11e7-8d42-83ea1941f011.png)

@ncameronbritt @jwforres 