### PR TITLE
[WIP] Don't dim images in subcategory tiles

### DIFF
--- a/dist/less/services-view.less
+++ b/dist/less/services-view.less
@@ -204,9 +204,6 @@ services-view,
           opacity: 1;
           position: absolute;
         }
-        .services-sub-category-tab-image img {
-          opacity: 1;
-        }
       }
 
       .services-sub-category-tab {
@@ -227,9 +224,6 @@ services-view,
         &:hover {
           color: @link-color;
           text-decoration: none;
-          .services-sub-category-tab-image img {
-            opacity: 1;
-          }
         }
       }
 
@@ -251,7 +245,6 @@ services-view,
           margin: auto;
           max-height: 36px;
           max-width: 36px;
-          opacity: .5;
           position: absolute;
           right: 0;
           top: 0;

--- a/dist/less/services-view.less
+++ b/dist/less/services-view.less
@@ -207,7 +207,7 @@ services-view,
       }
 
       .services-sub-category-tab {
-        color: @color-pf-black-500;
+        color: @text-color;
         display: flex;
         font-size: 14px;
         font-weight: 600;

--- a/dist/origin-web-catalogs.css
+++ b/dist/origin-web-catalogs.css
@@ -1208,9 +1208,6 @@ services-view .vendor-info-icon,
     opacity: 1;
     position: absolute;
   }
-  .services-view .services-sub-category.active .services-sub-category-tab .services-sub-category-tab-image img {
-    opacity: 1;
-  }
   .services-view .services-sub-category .services-sub-category-tab {
     color: #8b8d8f;
     display: flex;
@@ -1230,10 +1227,6 @@ services-view .vendor-info-icon,
     color: #0088ce;
     text-decoration: none;
   }
-  .services-view .services-sub-category .services-sub-category-tab:focus .services-sub-category-tab-image img,
-  .services-view .services-sub-category .services-sub-category-tab:hover .services-sub-category-tab-image img {
-    opacity: 1;
-  }
   .services-view .services-sub-category .services-sub-category-tab-icon,
   .services-view .services-sub-category .services-sub-category-tab-image {
     margin: 0 0 10px;
@@ -1251,7 +1244,6 @@ services-view .vendor-info-icon,
     margin: auto;
     max-height: 36px;
     max-width: 36px;
-    opacity: .5;
     position: absolute;
     right: 0;
     top: 0;

--- a/dist/origin-web-catalogs.css
+++ b/dist/origin-web-catalogs.css
@@ -1209,7 +1209,7 @@ services-view .vendor-info-icon,
     position: absolute;
   }
   .services-view .services-sub-category .services-sub-category-tab {
-    color: #8b8d8f;
+    color: #363636;
     display: flex;
     font-size: 14px;
     font-weight: 600;

--- a/src/styles/services-view.less
+++ b/src/styles/services-view.less
@@ -204,9 +204,6 @@ services-view,
           opacity: 1;
           position: absolute;
         }
-        .services-sub-category-tab-image img {
-          opacity: 1;
-        }
       }
 
       .services-sub-category-tab {
@@ -227,9 +224,6 @@ services-view,
         &:hover {
           color: @link-color;
           text-decoration: none;
-          .services-sub-category-tab-image img {
-            opacity: 1;
-          }
         }
       }
 
@@ -251,7 +245,6 @@ services-view,
           margin: auto;
           max-height: 36px;
           max-width: 36px;
-          opacity: .5;
           position: absolute;
           right: 0;
           top: 0;

--- a/src/styles/services-view.less
+++ b/src/styles/services-view.less
@@ -207,7 +207,7 @@ services-view,
       }
 
       .services-sub-category-tab {
-        color: @color-pf-black-500;
+        color: @text-color;
         display: flex;
         font-size: 14px;
         font-weight: 600;


### PR DESCRIPTION
This removes the dimming on the images on the subcategory tiles, which makes them look disabled. The tab text still highlights blue on hover. I don't know if we need a stronger effect on hover / selection, however. Opinions?

Recommendation per @serenamarie125 

![openshift web console 2017-11-06 13-26-26](https://user-images.githubusercontent.com/1167259/32457168-1c750ff8-c2f6-11e7-9afc-36cf3c3bcfea.png)

/kind bug
/assign @rhamilto @jwforres 
@openshift/team-ux-review 