### PR TITLE
Make modals fullscreen at < 768px width

### DIFF
--- a/dist/less/overlay-panel.less
+++ b/dist/less/overlay-panel.less
@@ -19,12 +19,44 @@ body.overlay-open {
 }
 
 .catalogs-overlay-panel {
-  margin: 0 auto;
-  max-width: 900px;
-  position: relative;
+  bottom: 0;
+  left: 0;
+  position: fixed;
+  right: 0;
+  top: 0;
+  @media(min-width: @screen-sm-min) {
+    margin: 0 auto;
+    max-width: 900px;
+    position: relative;
+  }
+  @media(min-width: @screen-sm-min) and (min-height: (@catalog-overlay-panel-height + @navbar-pf-height)) {
+    margin-top: @navbar-pf-height;
+  }
+
+  .modal-header .close {
+    font-size: 18px; // so that close button is the same size in console
+  }
+
+  .modal-title {
+    line-height: 21px; // so that modal-header has a consistent height of 41px
+  }
 
   .wizard-pf-contents {
     flex: 1 1 auto;
+  }
+
+  .wizard-pf-footer {
+    bottom: 0;
+    left: 0;
+    position: absolute;
+    right: 0;
+    @media(min-width: @screen-sm-min) {
+      position: relative;
+    }
+
+    .btn {
+      font-size: 12px; // so that wizard-pf-footer in the console is 58px tall
+    }
   }
 
   .wizard-pf-main {
@@ -36,13 +68,18 @@ body.overlay-open {
       .scroll-shadows-vertical-with-covers(65%, 0.25);
     }
     @media(max-width: @screen-xs-max) {
-      max-height: calc(100vh ~"-" 234px);
+      bottom: 58px; // height of .wizard-pf-footer
+      height: auto;
+      left: 1px;
+      position: fixed;
+      right: 1px;
+      top: 99px; // 99px = 98px (.order-service) + 1px (modal top "margin")
+      width: auto;
     }
     @media(min-width: @screen-sm-min) {
       height: @order-service-page-height + @grid-gutter-width;
-      max-height: calc(100vh ~"-" @order-service-wizard-min-external-height);
+      max-height: calc(100vh ~"-" 222px); // 222px =  1px (modal top "margin") + 41px (.modal-header) + 121px (.wizard-stesp) + 58 (.wizard-pf-footer) + 1px (modal bottom "margin")
       min-height: 200px;
-      overflow-y: auto;
     }
   }
 
@@ -102,13 +139,6 @@ body.overlay-open {
   }
   &.pficon-close:hover {
     color: @color-pf-black-800;
-  }
-}
-
-.catalogs-overlay-panel-grow-height {
-  // only adding padding to the overlay panel if the viewport is taller than the panel plus the padding
-  @media(min-height: 545px) and (min-width: @screen-sm-min) { // 465px (height of Safari in iPhone SE) + 80px (padding)
-    padding: @navbar-pf-height 0 (@grid-gutter-width / 2);
   }
 }
 

--- a/dist/less/variables.less
+++ b/dist/less/variables.less
@@ -1,5 +1,6 @@
 @card-icon-sm:                                        72px;
 @card-icon-xs:                                        24px;
+@catalog-overlay-panel-height:                        672px;
 @landing-bg:                                          url(@landing-image) no-repeat fixed @landing-main-bg;
 @landing-bg-position:                                 center top;
 @landing-bg-size:                                     cover;
@@ -17,7 +18,6 @@
 @navbar-height:                                       72px;
 @order-service-page-height:                           410px;
 @order-service-title-sm-min:                          450px;
-@order-service-wizard-min-external-height:            300px;
 @saas-hover:                                          fade(@color-pf-blue-700, 35%);
 @saas-border-bottom-color:                            fade(@color-pf-blue-700, 60%);
 @saas-text:                                           @color-pf-white;

--- a/dist/origin-web-catalogs.css
+++ b/dist/origin-web-catalogs.css
@@ -521,12 +521,46 @@ body.overlay-open .landing-side-bar {
   animation: modalBackdropOut 0.45s ease-out forwards;
 }
 .catalogs-overlay-panel {
-  margin: 0 auto;
-  max-width: 900px;
-  position: relative;
+  bottom: 0;
+  left: 0;
+  position: fixed;
+  right: 0;
+  top: 0;
+}
+@media (min-width: 768px) {
+  .catalogs-overlay-panel {
+    margin: 0 auto;
+    max-width: 900px;
+    position: relative;
+  }
+}
+@media (min-width: 768px) and (min-height: 732px) {
+  .catalogs-overlay-panel {
+    margin-top: 60px;
+  }
+}
+.catalogs-overlay-panel .modal-header .close {
+  font-size: 18px;
+}
+.catalogs-overlay-panel .modal-title {
+  line-height: 21px;
 }
 .catalogs-overlay-panel .wizard-pf-contents {
   flex: 1 1 auto;
+}
+.catalogs-overlay-panel .wizard-pf-footer {
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+}
+@media (min-width: 768px) {
+  .catalogs-overlay-panel .wizard-pf-footer {
+    position: relative;
+  }
+}
+.catalogs-overlay-panel .wizard-pf-footer .btn {
+  font-size: 12px;
 }
 .catalogs-overlay-panel .wizard-pf-main {
   display: flex;
@@ -549,15 +583,20 @@ body.overlay-open .landing-side-bar {
 }
 @media (max-width: 767px) {
   .catalogs-overlay-panel .wizard-pf-main {
-    max-height: calc(100vh - 234px);
+    bottom: 58px;
+    height: auto;
+    left: 1px;
+    position: fixed;
+    right: 1px;
+    top: 99px;
+    width: auto;
   }
 }
 @media (min-width: 768px) {
   .catalogs-overlay-panel .wizard-pf-main {
     height: 450px;
-    max-height: calc(100vh - 300px);
+    max-height: calc(100vh - 222px);
     min-height: 200px;
-    overflow-y: auto;
   }
 }
 .catalogs-overlay-panel .wizard-pf-main-form-contents {
@@ -618,11 +657,6 @@ body.overlay-open .landing-side-bar {
 }
 .catalogs-overlay-panel-close.pficon-close:hover {
   color: #393f44;
-}
-@media (min-height: 545px) and (min-width: 768px) {
-  .catalogs-overlay-panel-grow-height {
-    padding: 60px 0 20px;
-  }
 }
 .catalogs-overlay-panel-wrapper {
   bottom: 0;

--- a/src/styles/overlay-panel.less
+++ b/src/styles/overlay-panel.less
@@ -19,12 +19,44 @@ body.overlay-open {
 }
 
 .catalogs-overlay-panel {
-  margin: 0 auto;
-  max-width: 900px;
-  position: relative;
+  bottom: 0;
+  left: 0;
+  position: fixed;
+  right: 0;
+  top: 0;
+  @media(min-width: @screen-sm-min) {
+    margin: 0 auto;
+    max-width: 900px;
+    position: relative;
+  }
+  @media(min-width: @screen-sm-min) and (min-height: (@catalog-overlay-panel-height + @navbar-pf-height)) {
+    margin-top: @navbar-pf-height;
+  }
+
+  .modal-header .close {
+    font-size: 18px; // so that close button is the same size in console
+  }
+
+  .modal-title {
+    line-height: 21px; // so that modal-header has a consistent height of 41px
+  }
 
   .wizard-pf-contents {
     flex: 1 1 auto;
+  }
+
+  .wizard-pf-footer {
+    bottom: 0;
+    left: 0;
+    position: absolute;
+    right: 0;
+    @media(min-width: @screen-sm-min) {
+      position: relative;
+    }
+
+    .btn {
+      font-size: 12px; // so that wizard-pf-footer in the console is 58px tall
+    }
   }
 
   .wizard-pf-main {
@@ -36,13 +68,18 @@ body.overlay-open {
       .scroll-shadows-vertical-with-covers(65%, 0.25);
     }
     @media(max-width: @screen-xs-max) {
-      max-height: calc(100vh ~"-" 234px);
+      bottom: 58px; // height of .wizard-pf-footer
+      height: auto;
+      left: 1px;
+      position: fixed;
+      right: 1px;
+      top: 99px; // 99px = 98px (.order-service) + 1px (modal top "margin")
+      width: auto;
     }
     @media(min-width: @screen-sm-min) {
       height: @order-service-page-height + @grid-gutter-width;
-      max-height: calc(100vh ~"-" @order-service-wizard-min-external-height);
+      max-height: calc(100vh ~"-" 222px); // 222px =  1px (modal top "margin") + 41px (.modal-header) + 121px (.wizard-stesp) + 58 (.wizard-pf-footer) + 1px (modal bottom "margin")
       min-height: 200px;
-      overflow-y: auto;
     }
   }
 
@@ -102,13 +139,6 @@ body.overlay-open {
   }
   &.pficon-close:hover {
     color: @color-pf-black-800;
-  }
-}
-
-.catalogs-overlay-panel-grow-height {
-  // only adding padding to the overlay panel if the viewport is taller than the panel plus the padding
-  @media(min-height: 545px) and (min-width: @screen-sm-min) { // 465px (height of Safari in iPhone SE) + 80px (padding)
-    padding: @navbar-pf-height 0 (@grid-gutter-width / 2);
   }
 }
 

--- a/src/styles/variables.less
+++ b/src/styles/variables.less
@@ -1,5 +1,6 @@
 @card-icon-sm:                                        72px;
 @card-icon-xs:                                        24px;
+@catalog-overlay-panel-height:                        672px;
 @landing-bg:                                          url(@landing-image) no-repeat fixed @landing-main-bg;
 @landing-bg-position:                                 center top;
 @landing-bg-size:                                     cover;
@@ -17,7 +18,6 @@
 @navbar-height:                                       72px;
 @order-service-page-height:                           410px;
 @order-service-title-sm-min:                          450px;
-@order-service-wizard-min-external-height:            300px;
 @saas-hover:                                          fade(@color-pf-blue-700, 35%);
 @saas-border-bottom-color:                            fade(@color-pf-blue-700, 60%);
 @saas-text:                                           @color-pf-white;


### PR DESCRIPTION
Supports https://github.com/openshift/origin-web-console/issues/2442

Since [VH units are essentially unusable on mobile devices](https://stackoverflow.com/a/37113430), this PR changes the modal to use fixed positioning at mobile screen sizes (viewport width < 767px) so that the modal is always the full-size of the viewport (thus eliminating the flicker) without the mobile browser chrome overlaying the footer.

Additionally, I improved upon the layout for desktop resolutions so that shorter viewport heights maximize the available space.

![screen shot 2017-11-09 at 9 37 33 am](https://user-images.githubusercontent.com/895728/32620428-bcc679a4-c54b-11e7-96d1-23416c8e1fde.PNG)

![screen shot 2017-11-09 at 2 38 23 pm](https://user-images.githubusercontent.com/895728/32625943-c9e5a41a-c55b-11e7-892d-fd5f2276c871.PNG)

