### PR TITLE
Bug 1512858 - Don't request service classes and plans for builders

### DIFF
--- a/dist/origin-web-catalogs.js
+++ b/dist/origin-web-catalogs.js
@@ -1323,7 +1323,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             }), this.ctrl.showPodPresets ? (this.getServiceClassesAndPlans(), this.instancesSupported = !!this.APIService.apiInfo(this.APIService.getPreferredVersion("serviceinstances"))) : this.instancesSupported = !1, 
             this.noProjectsCantCreateWatch = this.$scope.$on("no-projects-cannot-create", function() {
                 e.ctrl.noProjectsCantCreate = !0;
-            }), this.getServiceClassesAndPlans(), this.instancesSupported = !!this.APIService.apiInfo(this.APIService.getPreferredVersion("serviceinstances"));
+            });
         }, e.prototype.closePanel = function() {
             n.isFunction(this.ctrl.handleClose) && this.ctrl.handleClose();
         }, e.prototype.$onDestroy = function() {

--- a/src/components/create-from-builder/create-from-builder.controller.ts
+++ b/src/components/create-from-builder/create-from-builder.controller.ts
@@ -144,9 +144,6 @@ export class CreateFromBuilderController implements angular.IController {
     this.noProjectsCantCreateWatch = this.$scope.$on('no-projects-cannot-create', () => {
       this.ctrl.noProjectsCantCreate = true;
     });
-
-    this.getServiceClassesAndPlans();
-    this.instancesSupported = !!this.APIService.apiInfo(this.APIService.getPreferredVersion('serviceinstances'));
   }
 
   public closePanel() {


### PR DESCRIPTION
Don't try to request service classes or plans in the create from builder
dialogs when pod presets are disabled.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1512858

/kind bug
/assign @jwforres 