### PR TITLE
Fix project size check for projects sidebar

### DIFF
--- a/app/mockServices/mockData.service.ts
+++ b/app/mockServices/mockData.service.ts
@@ -272,15 +272,15 @@ export class DataService implements IDataService {
   }
 
   private getLargeProjectList() {
-    if (this.largeProjectList) {
-      return this.largeProjectList;
+    if (!this.largeProjectList) {
+      this.largeProjectList = {};
+      for (let i = 1; i <= 5000; i++) {
+        let project = this.mockProject(i);
+        this.largeProjectList[project.metadata.name] = project;
+      }
     }
 
-    this.largeProjectList = {};
-    for (let i = 1; i <= 5000; i++) {
-      let project = this.mockProject(i);
-      this.largeProjectList[project.metadata.name] = project;
-    }
+    return this.largeProjectList;
   }
 
   private watchCallbacks(key: string) {

--- a/dist/origin-web-catalogs.js
+++ b/dist/origin-web-catalogs.js
@@ -1745,11 +1745,10 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
         function e(t, r, a, s, c, o, l, d, p, h, m) {
             var u = this;
             this.ctrl = this, this.newProjectPanelShown = !1, this.editProjectPanelShown = !1, 
-            this.projects = [], this.watches = [], this.maxDisplayProjects = 5, this.watchingProjects = !1, 
-            this.init = function() {
+            this.watches = [], this.maxDisplayProjects = 5, this.watchingProjects = !1, this.init = function() {
                 u.ProjectsService.list().then(function(t) {
                     u.onProjectsUpdate(t), u.ctrl.isProjectListIncomplete = u.ProjectsService.isProjectListIncomplete(), 
-                    !u.ctrl.isProjectListIncomplete && i.size(u.projects) <= e.MAX_PROJETS_TO_WATCH && (u.watches.push(u.ProjectsService.watch(u.$scope, u.onProjectsUpdate)), 
+                    !u.ctrl.isProjectListIncomplete && u.ctrl.totalProjects <= e.MAX_PROJETS_TO_WATCH && (u.watches.push(u.ProjectsService.watch(u.$scope, u.onProjectsUpdate)), 
                     u.watchingProjects = !0);
                 }, function() {
                     u.ctrl.isProjectListIncomplete = !0;

--- a/src/components/projects-summary/projects-summary.controller.ts
+++ b/src/components/projects-summary/projects-summary.controller.ts
@@ -22,7 +22,6 @@ export class ProjectsSummaryController implements angular.IController {
   public ctrl: any = this;
   public newProjectPanelShown: boolean = false;
   public editProjectPanelShown: boolean = false;
-  public projects: any = [];
   private $filter: any;
   private $rootScope: any;
   private $scope: any;
@@ -123,7 +122,7 @@ export class ProjectsSummaryController implements angular.IController {
       // Only watch if the list successfully completed and we are below the
       // maximum number of projects to watch. Otherwise the list is likely too
       // large to reliably watch.
-      if (!this.ctrl.isProjectListIncomplete && _.size(this.projects) <= ProjectsSummaryController.MAX_PROJETS_TO_WATCH) {
+      if (!this.ctrl.isProjectListIncomplete && this.ctrl.totalProjects <= ProjectsSummaryController.MAX_PROJETS_TO_WATCH) {
         this.watches.push(this.ProjectsService.watch(this.$scope, this.onProjectsUpdate));
         // If we're not watching projects, we can manually update the list
         // on changes.


### PR DESCRIPTION
Correctly check the projects size before attempting to watch projects.

Also fixes the mock data service to correctly return a large project list on the first call to `list()`.