### PR TITLE
Do not store categories or vendors in Catalog service

### DIFF
--- a/dist/origin-web-catalogs.js
+++ b/dist/origin-web-catalogs.js
@@ -49,6 +49,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
     t.catalogFilter = {
         bindings: {
             config: "<",
+            vendors: "<",
             filterOnKeyword: "<",
             applyFilters: "&"
         },
@@ -688,8 +689,8 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
     t.__esModule = !0;
     var n = r(1), i = r(0), a = function() {
         function e(e, t, r, n, i, a) {
-            this.vendors = [], this.$filter = e, this.$q = t, this.constants = r, this.apiService = n, 
-            this.dataService = i, this.logger = a;
+            this.$filter = e, this.$q = t, this.constants = r, this.apiService = n, this.dataService = i, 
+            this.logger = a;
         }
         return e.prototype.getCatalogItems = function(e) {
             var t = this, r = this.$q.defer(), n = {}, a = 0, s = 0, c = [], o = this.apiService.getPreferredVersion("clusterserviceclasses");
@@ -773,15 +774,8 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             }).finally(function() {
                 i.returnCatalogItems(a, s, ++o, c, l);
             })), a.promise;
-        }, e.prototype.convertToServiceItems = function(e, t, r) {
-            var n = this, a = i.map(e, function(e) {
-                return n.getServiceItem(e);
-            });
-            return a = a.concat(i.map(t, function(e) {
-                return n.getImageItem(e);
-            })), a = a.concat(i.map(r, function(e) {
-                return n.getTemplateItem(e);
-            })), a = i.reject(a, "hidden"), a = a.sort(function(e, t) {
+        }, e.prototype.sortCatalogItems = function(e) {
+            return e.sort(function(e, t) {
                 var r = i.get(e, "name", "").localeCompare(i.get(t, "name", ""), void 0, {
                     sensitivity: "base"
                 });
@@ -790,7 +784,16 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
                 })), 0 === r && (r = i.get(e, "resource.metadata.name", "").localeCompare(i.get(t, "resource.metadata.name", ""), void 0, {
                     sensitivity: "base"
                 })), r;
-            }), this.categorizeItems(a), a;
+            });
+        }, e.prototype.convertToServiceItems = function(e, t, r) {
+            var n = this, a = i.map(e, function(e) {
+                return n.getServiceItem(e);
+            });
+            return a = a.concat(i.map(t, function(e) {
+                return n.getImageItem(e);
+            })), a = a.concat(i.map(r, function(e) {
+                return n.getTemplateItem(e);
+            })), a = i.reject(a, "hidden"), a = this.sortCatalogItems(a);
         }, e.prototype.getServiceItem = function(e) {
             return new s(e, this);
         }, e.prototype.getImageItem = function(e) {
@@ -802,11 +805,11 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
         }, e.prototype.getImageForIconClass = function(e) {
             return this.$filter("imageForIconClass")(e);
         }, e.prototype.categorizeItems = function(e) {
-            var t, r, a = this;
-            this.categories = n.copy(this.constants.SERVICE_CATALOG_CATEGORIES), this.createAllAndOtherMainCategories();
-            var s = i.head(this.categories), c = i.get(s, "subCategories[0]"), o = i.last(this.categories), l = i.get(o, "subCategories[0]"), d = {};
-            i.each(e, function(e) {
-                e.vendor && (d[e.vendor] = !0), r = !1, i.each(a.categories, function(n) {
+            var t, r, a = this, s = n.copy(this.constants.SERVICE_CATALOG_CATEGORIES);
+            this.createAllAndOtherMainCategories(s);
+            var c = i.head(s), o = i.get(c, "subCategories[0]"), l = i.last(s), d = i.get(l, "subCategories[0]");
+            return i.each(e, function(e) {
+                r = !1, i.each(s, function(n) {
                     n.tags ? a.hasMatchingTags(n.tags, e.tags) && (r = a.categorizeItem(e, n, "all"), 
                     t = a.filterSubCatsByTags(n.subCategories, e.tags), i.isEmpty(t) ? a.categorizeItem(e, n, "other") : i.each(t, function(t) {
                         a.categorizeItem(e, n, t);
@@ -814,20 +817,25 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
                     i.each(t, function(t) {
                         a.categorizeItem(e, n, t);
                     })));
-                }), r || a.categorizeItem(e, o, l), a.categorizeItem(e, s, c);
-            }), this.vendors = i.keys(d).sort();
+                }), r || a.categorizeItem(e, l, d), a.categorizeItem(e, c, o);
+            }), s;
+        }, e.prototype.getVendors = function(e) {
+            var t = {};
+            return i.each(e, function(e) {
+                e.vendor && (t[e.vendor] = !0);
+            }), i.keys(t).sort();
         }, e.prototype.categorizeItem = function(e, t, r) {
             return i.isString(r) && (r = this.getAllOrOtherSubCategory(t, r)), r.items = i.isArray(r.items) ? r.items.concat([ e ]) : [ e ], 
             t.hasItems = r.hasItems = !0;
-        }, e.prototype.createAllAndOtherMainCategories = function() {
-            this.categories.unshift({
+        }, e.prototype.createAllAndOtherMainCategories = function(e) {
+            e.unshift({
                 id: "all",
                 label: "All",
                 subCategories: [ {
                     id: "all",
                     label: "All"
                 } ]
-            }), this.categories.push({
+            }), e.push({
                 id: "other",
                 label: "Other",
                 subCategories: [ {
@@ -1008,7 +1016,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
 }, function(e, t) {
     e.exports = '<span ng-if="$ctrl.noProjectsCantCreate" class="no-projects-cant-create">\n  <pf-empty-state config="$ctrl.noProjectsConfig"></pf-empty-state>\n  <p ng-if="!$ctrl.noProjectsCantCreateMessage">\n    A cluster admin can create a project for you by running the command:\n    <div class="code-block">\n      <code>oc adm <span class="command-arg">new-project</span> &lt;projectname&gt; <span class="command-arg">--admin={{$ctrl.user.metadata.name || \'&lt;YourUsername&gt;\'}}</span></code>\n    </div>\n  </p>\n  <div ng-if="$ctrl.noProjectsCantCreateMessage" ng-bind-html="$ctrl.noProjectsCantCreateMessage | linky : \'_blank\'"></div>\n</span>\n\n\x3c!-- Use `ng-show` instead of `ng-if` so that the form exists and the `canI` works when projects load. --\x3e\n<ng-form name="$ctrl.forms.selectProjectForm" ng-show="$ctrl.numProjectChoices >= 1">\n  <div class="form-group" ng-class="{\'has-error\' : $ctrl.forms.selectProjectForm.selectProject.$error.cannotAddToProject ||\n                                                   ($ctrl.forms.selectProjectForm.selectProject.$touched &&\n                                                    $ctrl.forms.selectProjectForm.selectProject.$invalid)}">\n    <h3 ng-if="$ctrl.canOnlyCreateProject()">Create Project</h3>\n    <label ng-if="!$ctrl.canOnlyCreateProject() && !$ctrl.hideLabel" class="control-label required">Add to Project</label>\n    <ui-select\n        ng-if="!$ctrl.canOnlyCreateProject()"\n        ng-disabled="$ctrl.numProjectChoices === 1"\n        name="selectProject"\n        ng-model="$ctrl.selectedProject"\n        ng-change="$ctrl.onSelectProjectChange()"\n        ng-required="true"\n        search-enabled="$ctrl.searchEnabled"\n        uis-open-close="$ctrl.onOpenClose(isOpen)">\n      <ui-select-match placeholder="{{$ctrl.placeholder}}">\n        {{$select.selected | displayName}}\n      </ui-select-match>\n      \x3c!-- refresh-delay must be set using ng-attr-refresh-delay to work as a dynamic value --\x3e\n      <ui-select-choices\n          repeat="project in $ctrl.getProjectChoices() track by (project | uid)"\n          refresh="$ctrl.refreshChoices($select.search)"\n          ng-attr-refresh-delay="{{$ctrl.refreshDelay}}"\n          group-by="$ctrl.groupChoicesBy">\n        <span ng-bind-html="project | displayName | highlightKeywords : $select.search"></span>\n        <span ng-if="project | displayName : true" class="small text-muted">\n          <span ng-if="project.metadata.name">&ndash;</span>\n          <span ng-bind-html="project.metadata.name | highlightKeywords : $select.search"></span>\n        </span>\n      </ui-select-choices>\n    </ui-select>\n    <div ng-if="$ctrl.forms.selectProjectForm.selectProject.$error.cannotAddToProject">\n        <span class="help-block">\n          You are not authorized to add to this project.\n        </span>\n    </div>\n    <div class="has-error" ng-if="$ctrl.forms.selectProjectForm.selectProject.$error.required &&\n                                  $ctrl.forms.selectProjectForm.selectProject.$touched">\n      <span class="help-block">\n        Please select <span ng-if="$ctrl.canCreate && !$ctrl.hideCreateProject">or create</span> a project.\n      </span>\n    </div>\n  </div>\n</ng-form>\n\n<ng-form name="$ctrl.forms.createProjectForm"\n    ng-if="$ctrl.isNewProject()">\n  <div class="form-group">\n    <label for="name" class="control-label required">Project Name</label>\n    <div ng-class="{\'has-error\': ($ctrl.forms.createProjectForm.name.$error.pattern && $ctrl.forms.createProjectForm.name.$touched) ||\n                                 $ctrl.nameTaken || $ctrl.forms.createProjectForm.name.$error.oscUnique}">\n      <input class="form-control"\n          name="name"\n          id="name"\n          placeholder="my-project"\n          type="text"\n          required\n          take-focus\n          minlength="2"\n          maxlength="63"\n          pattern="[a-z0-9]([-a-z0-9]*[a-z0-9])?"\n          aria-describedby="nameHelp"\n          ng-model="$ctrl.selectedProject.metadata.name"\n          osc-unique="$ctrl.existingProjectNames"\n          ng-model-options="{ updateOn: \'default blur\' }"\n          ng-change="$ctrl.onNewProjectNameChange()"\n          autocorrect="off"\n          autocapitalize="off"\n          spellcheck="false">\n    </div>\n    <div class="help-block">A unique name for the project.</div>\n    <div class="has-error" ng-if="$ctrl.forms.createProjectForm.name.$error.minlength && $ctrl.forms.createProjectForm.name.$touched">\n      <span id="nameHelp" class="help-block">\n        Name must have at least two characters.\n      </span>\n    </div>\n    <div class="has-error" ng-if="$ctrl.forms.createProjectForm.name.$error.pattern && $ctrl.forms.createProjectForm.name.$touched">\n      <span id="nameHelp" class="help-block">\n        Project names may only contain lower-case letters, numbers, and dashes.\n        They may not start or end with a dash.\n      </span>\n    </div>\n    <div class="has-error" ng-if="$ctrl.nameTaken || $ctrl.forms.createProjectForm.name.$error.oscUnique">\n      <span class="help-block">\n        This name is already in use. Please choose a different name.\n      </span>\n    </div>\n  </div>\n\n  <div class="form-group">\n    <label for="displayName" class="control-label">Project Display Name</label>\n    <input class="form-control"\n      name="displayName"\n      id="displayName"\n      placeholder="My Project"\n      type="text"\n      ng-model="$ctrl.selectedProject.metadata.annotations[\'new-display-name\']">\n  </div>\n\n  <div class="form-group">\n    <label for="description" class="control-label">Project Description</label>\n    <textarea class="form-control"\n      name="description"\n      id="description"\n      placeholder="A short description."\n      ng-model="$ctrl.selectedProject.metadata.annotations[\'openshift.io/description\']"></textarea>\n  </div>\n</ng-form>\n<div ng-if="!$ctrl.noProjectsCantCreate && $ctrl.showDivider" class="select-project-divider"></div>\n\n';
 }, function(e, t) {
-    e.exports = '<div class="services-view" ng-style="$ctrl.viewStyle">\n  <div ng-if="!$ctrl.loaded" class="spinner-container">\n    <div class="spinner spinner-xl"></div>\n  </div>\n  <div ng-if="$ctrl.loaded" class="services-view-container mobile-{{$ctrl.mobileView}}-view">\n    <div class="add-methods">\n      <h1>{{$ctrl.sectionTitle}}</h1>\n      <div ng-if="$ctrl.onDeployImageSelected || $ctrl.onFromFileSelected || $ctrl.onCreateFromProject">\n        <ul class="add-other hidden-md hidden-lg">\n          <li uib-dropdown="" class="dropdown">\n            <a uib-dropdown-toggle="" class="dropdown-toggle" id="add-methods-dropdown" href="" aria-haspopup="true" aria-expanded="false">\n              Custom Add\n              <span class="caret" aria-hidden="true"></span>\n            </a>\n            <ul class="uib-dropdown-menu dropdown-menu pull-right" aria-labelledby="add-methods-dropdown">\n              \x3c!-- note these are duplicated below --\x3e\n              <li ng-if="$ctrl.onDeployImageSelected">\n                <a href="" ng-click="$ctrl.onDeployImageSelected()">Deploy Image</a>\n              </li>\n              <li ng-if="$ctrl.onFromFileSelected">\n                <a href="" ng-click="$ctrl.onFromFileSelected()">Import YAML / JSON</a>\n              </li>\n              <li ng-if="$ctrl.onCreateFromProject">\n                <a href="" ng-click="$ctrl.onCreateFromProject()">Select from Project</a>\n              </li>\n            </ul>\n          </li>\n        </ul>\n        <ul class="add-other hidden-xs hidden-sm">\n          \x3c!-- note these are duplicated above --\x3e\n          <li ng-if="$ctrl.onDeployImageSelected">\n            <a href="" ng-click="$ctrl.onDeployImageSelected()">Deploy Image</a>\n          </li>\n          <li ng-if="$ctrl.onFromFileSelected">\n            <a href="" ng-click="$ctrl.onFromFileSelected()">Import YAML / JSON</a>\n          </li>\n          <li ng-if="$ctrl.onCreateFromProject">\n            <a href="" ng-click="$ctrl.onCreateFromProject()">Select from Project</a>\n          </li>\n        </ul>\n      </div>\n    </div>\n    <ul class="nav nav-tabs nav-tabs-pf services-categories">\n      <li ng-repeat="category in $ctrl.categories"\n          ng-if="category.hasItems"\n          ng-class="{ active: $ctrl.currentFilter === category.id }">\n        <a href="" id="{{\'category-\'+category.id}}" class="services-category-heading" ng-click="$ctrl.selectCategory(category.id)">{{category.label}}</a>\n        <a ng-click="$ctrl.mobileView = \'categories\'" class="services-back-link" href="">Back</a>\n      </li>\n    </ul>\n\n    <div class="services-inner-container">\n      \x3c!-- Do not show sub-category items for \'All\' or \'Other\' main categories --\x3e\n      <ul class="services-sub-categories"\n          ng-if="$ctrl.currentFilter !== \'other\' && $ctrl.currentFilter !== \'all\'">\n        <li ng-repeat="subCategory in $ctrl.subCategories track by subCategory.id"\n             ng-if="subCategory.hasItems"\n             ng-attr-id="{{subCategory.id}}"\n             class="services-sub-category"\n             ng-class="{ active: $ctrl.currentSubFilter === subCategory.id }">\n          <a href="" id="{{\'services-sub-category-\'+subCategory.id}}"\n             class="services-sub-category-tab" ng-click="$ctrl.selectSubCategory(subCategory.id)">\n            <div class="services-sub-category-tab-image" ng-if="imageUrl = (subCategory.imageUrl || (subCategory.icon | imageForIconClass))">\n              <img ng-src="{{imageUrl}}" alt="">\n            </div>\n            <div class="services-sub-category-tab-icon {{subCategory.icon}}"\n                ng-class="{ \'font-icon\': !subCategory.icon.contains(\'fa \') }"\n                ng-if="subCategory.icon && !subCategory.imageUrl && !(subCategory.icon | imageForIconClass)"></div>\n            <div class="services-sub-category-tab-name">{{subCategory.label}}</div>\n          </a>\n         <a ng-click="$ctrl.mobileView = \'subcategories\'" class="services-back-link" href="">Back</a>\n          <div ng-if="$ctrl.currentSubFilter === subCategory.id" class="services-items">\n            <catalog-filter class="services-items-filter"\n                            config="$ctrl.filterConfig"\n                            filter-on-keyword="$ctrl.keywordFilterValue"\n                            apply-filters="$ctrl.applyFilters($event)">\n            </catalog-filter>\n            <div class="pf-empty-state" ng-if="$ctrl.filterConfig.appliedFilters.length > 0 && $ctrl.filterConfig.resultsCount === 0">\n              <pf-empty-state config="$ctrl.emptyFilterConfig"></pf-empty-state>\n            </div>\n            <a href="" class="services-item" ng-repeat="item in $ctrl.filteredItems track by item.resource.metadata.uid" ng-click="$ctrl.serviceViewItemClicked(item)">\n              <div ng-if="!item.imageUrl" class="services-item-icon">\n                <span class="{{item.iconClass}}"></span>\n              </div>\n              <div ng-if="item.imageUrl" class="services-item-icon">\n                <img ng-src="{{item.imageUrl}}" alt="">\n              </div>\n              <div class="services-item-name" title="{{item.name}}">\n                {{item.name}}\n              </div>\n            </a>\n          </div>\n        </li>\n      </ul>\n\n      \x3c!-- Show catalog item for \'All\' and \'Other\' main categories --\x3e\n      <div ng-if="$ctrl.currentFilter === \'other\' || $ctrl.currentFilter === \'all\'" class="services-no-sub-categories">\n        <div class="services-items">\n          <div ng-if="$ctrl.isEmpty">There are no catalog items.</div>\n          <catalog-filter ng-if="!$ctrl.isEmpty"\n                          class="services-items-filter"\n                          config="$ctrl.filterConfig"\n                          filter-on-keyword="$ctrl.keywordFilterValue"\n                          apply-filters="$ctrl.applyFilters($event)">\n          </catalog-filter>\n          <div class="pf-empty-state" ng-if="$ctrl.filterConfig.appliedFilters.length > 0 && $ctrl.filterConfig.resultsCount === 0">\n            <pf-empty-state config="$ctrl.emptyFilterConfig"></pf-empty-state>\n          </div>\n          <a href="" class="services-item" ng-repeat="item in $ctrl.filteredItems track by item.resource.metadata.uid" ng-click="$ctrl.serviceViewItemClicked(item)">\n            <div ng-if="!item.imageUrl" class="services-item-icon">\n              <span class="{{item.iconClass}}"></span>\n            </div>\n            <div ng-if="item.imageUrl" class="services-item-icon">\n              <img ng-src="{{item.imageUrl}}" alt="">\n            </div>\n            <div class="services-item-name" title="{{item.name}}">\n              {{item.name}}\n            </div>\n          </a>\n        </div>\n      </div>\n    </div>\n  </div>\n</div>\n';
+    e.exports = '<div class="services-view" ng-style="$ctrl.viewStyle">\n  <div ng-if="!$ctrl.loaded" class="spinner-container">\n    <div class="spinner spinner-xl"></div>\n  </div>\n  <div ng-if="$ctrl.loaded" class="services-view-container mobile-{{$ctrl.mobileView}}-view">\n    <div class="add-methods">\n      <h1>{{$ctrl.sectionTitle}}</h1>\n      <div ng-if="$ctrl.onDeployImageSelected || $ctrl.onFromFileSelected || $ctrl.onCreateFromProject">\n        <ul class="add-other hidden-md hidden-lg">\n          <li uib-dropdown="" class="dropdown">\n            <a uib-dropdown-toggle="" class="dropdown-toggle" id="add-methods-dropdown" href="" aria-haspopup="true" aria-expanded="false">\n              Custom Add\n              <span class="caret" aria-hidden="true"></span>\n            </a>\n            <ul class="uib-dropdown-menu dropdown-menu pull-right" aria-labelledby="add-methods-dropdown">\n              \x3c!-- note these are duplicated below --\x3e\n              <li ng-if="$ctrl.onDeployImageSelected">\n                <a href="" ng-click="$ctrl.onDeployImageSelected()">Deploy Image</a>\n              </li>\n              <li ng-if="$ctrl.onFromFileSelected">\n                <a href="" ng-click="$ctrl.onFromFileSelected()">Import YAML / JSON</a>\n              </li>\n              <li ng-if="$ctrl.onCreateFromProject">\n                <a href="" ng-click="$ctrl.onCreateFromProject()">Select from Project</a>\n              </li>\n            </ul>\n          </li>\n        </ul>\n        <ul class="add-other hidden-xs hidden-sm">\n          \x3c!-- note these are duplicated above --\x3e\n          <li ng-if="$ctrl.onDeployImageSelected">\n            <a href="" ng-click="$ctrl.onDeployImageSelected()">Deploy Image</a>\n          </li>\n          <li ng-if="$ctrl.onFromFileSelected">\n            <a href="" ng-click="$ctrl.onFromFileSelected()">Import YAML / JSON</a>\n          </li>\n          <li ng-if="$ctrl.onCreateFromProject">\n            <a href="" ng-click="$ctrl.onCreateFromProject()">Select from Project</a>\n          </li>\n        </ul>\n      </div>\n    </div>\n    <ul class="nav nav-tabs nav-tabs-pf services-categories">\n      <li ng-repeat="category in $ctrl.categories"\n          ng-if="category.hasItems"\n          ng-class="{ active: $ctrl.currentFilter === category.id }">\n        <a href="" id="{{\'category-\'+category.id}}" class="services-category-heading" ng-click="$ctrl.selectCategory(category.id)">{{category.label}}</a>\n        <a ng-click="$ctrl.mobileView = \'categories\'" class="services-back-link" href="">Back</a>\n      </li>\n    </ul>\n\n    <div class="services-inner-container">\n      \x3c!-- Do not show sub-category items for \'All\' or \'Other\' main categories --\x3e\n      <ul class="services-sub-categories"\n          ng-if="$ctrl.currentFilter !== \'other\' && $ctrl.currentFilter !== \'all\'">\n        <li ng-repeat="subCategory in $ctrl.subCategories track by subCategory.id"\n             ng-if="subCategory.hasItems"\n             ng-attr-id="{{subCategory.id}}"\n             class="services-sub-category"\n             ng-class="{ active: $ctrl.currentSubFilter === subCategory.id }">\n          <a href="" id="{{\'services-sub-category-\'+subCategory.id}}"\n             class="services-sub-category-tab" ng-click="$ctrl.selectSubCategory(subCategory.id)">\n            <div class="services-sub-category-tab-image" ng-if="imageUrl = (subCategory.imageUrl || (subCategory.icon | imageForIconClass))">\n              <img ng-src="{{imageUrl}}" alt="">\n            </div>\n            <div class="services-sub-category-tab-icon {{subCategory.icon}}"\n                ng-class="{ \'font-icon\': !subCategory.icon.contains(\'fa \') }"\n                ng-if="subCategory.icon && !subCategory.imageUrl && !(subCategory.icon | imageForIconClass)"></div>\n            <div class="services-sub-category-tab-name">{{subCategory.label}}</div>\n          </a>\n         <a ng-click="$ctrl.mobileView = \'subcategories\'" class="services-back-link" href="">Back</a>\n          <div ng-if="$ctrl.currentSubFilter === subCategory.id" class="services-items">\n            <catalog-filter class="services-items-filter"\n                            config="$ctrl.filterConfig"\n                            vendors="$ctrl.vendors"\n                            filter-on-keyword="$ctrl.keywordFilterValue"\n                            apply-filters="$ctrl.applyFilters($event)">\n            </catalog-filter>\n            <div class="pf-empty-state" ng-if="$ctrl.filterConfig.appliedFilters.length > 0 && $ctrl.filterConfig.resultsCount === 0">\n              <pf-empty-state config="$ctrl.emptyFilterConfig"></pf-empty-state>\n            </div>\n            <a href="" class="services-item" ng-repeat="item in $ctrl.filteredItems track by item.resource.metadata.uid" ng-click="$ctrl.serviceViewItemClicked(item)">\n              <div ng-if="!item.imageUrl" class="services-item-icon">\n                <span class="{{item.iconClass}}"></span>\n              </div>\n              <div ng-if="item.imageUrl" class="services-item-icon">\n                <img ng-src="{{item.imageUrl}}" alt="">\n              </div>\n              <div class="services-item-name" title="{{item.name}}">\n                {{item.name}}\n              </div>\n            </a>\n          </div>\n        </li>\n      </ul>\n\n      \x3c!-- Show catalog item for \'All\' and \'Other\' main categories --\x3e\n      <div ng-if="$ctrl.currentFilter === \'other\' || $ctrl.currentFilter === \'all\'" class="services-no-sub-categories">\n        <div class="services-items">\n          <div ng-if="$ctrl.isEmpty">There are no catalog items.</div>\n          <catalog-filter ng-if="!$ctrl.isEmpty"\n                          class="services-items-filter"\n                          config="$ctrl.filterConfig"\n                          vendors="$ctrl.vendors"\n                          filter-on-keyword="$ctrl.keywordFilterValue"\n                          apply-filters="$ctrl.applyFilters($event)">\n          </catalog-filter>\n          <div class="pf-empty-state" ng-if="$ctrl.filterConfig.appliedFilters.length > 0 && $ctrl.filterConfig.resultsCount === 0">\n            <pf-empty-state config="$ctrl.emptyFilterConfig"></pf-empty-state>\n          </div>\n          <a href="" class="services-item" ng-repeat="item in $ctrl.filteredItems track by item.resource.metadata.uid" ng-click="$ctrl.serviceViewItemClicked(item)">\n            <div ng-if="!item.imageUrl" class="services-item-icon">\n              <span class="{{item.iconClass}}"></span>\n            </div>\n            <div ng-if="item.imageUrl" class="services-item-icon">\n              <img ng-src="{{item.imageUrl}}" alt="">\n            </div>\n            <div class="services-item-name" title="{{item.name}}">\n              {{item.name}}\n            </div>\n          </a>\n        </div>\n      </div>\n    </div>\n  </div>\n</div>\n';
 }, function(e, t) {
     e.exports = '<div class="order-service">\n  <pf-wizard wizard-title="{{$ctrl.displayName}}"\n             hide-sidebar="true"\n             step-class="order-service-wizard-step"\n             wizard-ready="$ctrl.wizardReady"\n             next-title="$ctrl.nextTitle"\n             on-finish="$ctrl.closePanel()"\n             on-cancel="$ctrl.closePanel()"\n             wizard-done="$ctrl.wizardDone"\n             hide-back-button="{{$ctrl.hideBackButton}}">\n    <pf-wizard-step ng-repeat="step in $ctrl.steps track by step.id"\n                    step-title="{{step.label}}"\n                    wz-disabled="{{step.hidden}}"\n                    allow-click-nav="step.allowClickNav"\n                    next-enabled="step.valid && !$ctrl.updating"\n                    prev-enabled="step.prevEnabled"\n                    on-show="step.onShow"\n                    step-id="{{step.id}}"\n                    step-priority="{{$index}}">\n      <div class="wizard-pf-main-inner-shadow-covers">\n        <div ng-include="step.view" class="wizard-pf-main-form-contents"></div>\n      </div>\n    </pf-wizard-step>\n  </pf-wizard>\n</div>\n';
 }, function(e, t, r) {
@@ -1025,38 +1033,41 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             }, this.onFilterChange = function(e, t, i) {
                 n.isDefined(t) && n.isDefined(i) ? r.updateFilterPanelModel(t, i) : r.resetFilterPanelModel(), 
                 r.constructFiltersFromModel();
-            }, this.$scope = e, this.Catalog = t;
-        }
-        return e.prototype.$onInit = function() {
-            var e = this;
-            this.ctrl.filterPanelModel = [], this.ctrl.keywordFilter = {
+            }, this.$scope = e, this.Catalog = t, this.ctrl.filterPanelModel = [], this.ctrl.keywordFilter = {
                 id: "keyword",
                 title: "Keyword",
                 placeholder: "Filter by Keyword",
                 filterType: "text",
                 values: []
-            }, this.ctrl.filterPanelModel.push(this.ctrl.keywordFilter), i.isEmpty(this.Catalog.vendors) || (this.ctrl.VendorFilter = {
-                id: "vendors",
-                title: "Publisher",
-                filterType: "checkbox",
-                values: i.map(this.Catalog.vendors, function(e) {
-                    return {
-                        id: e,
-                        title: e,
-                        value: e,
-                        selected: !1
-                    };
-                })
-            }, this.ctrl.filterPanelModel.push(this.ctrl.VendorFilter)), this.ctrl.filterOnKeyword && (this.ctrl.keywordFilter.values = [ this.ctrl.filterOnKeyword ], 
+            }, this.ctrl.filterPanelModel.push(this.ctrl.keywordFilter);
+        }
+        return e.prototype.$onInit = function() {
+            var e = this;
+            this.ctrl.filterOnKeyword && (this.ctrl.keywordFilter.values = [ this.ctrl.filterOnKeyword ], 
             this.constructFiltersFromModel()), this.ctrl.config.onFilterChange = this.onFilterChange, 
             this.removeClearFilterListener = this.$scope.$on("clear-filters", function() {
                 e.resetFilterPanelModel(), e.constructFiltersFromModel();
             });
         }, e.prototype.$onChanges = function(e) {
             e.filterOnKeyword && e.filterOnKeyword.currentValue && this.ctrl.keywordFilter && (this.resetFilterPanelModel(), 
-            this.ctrl.keywordFilter.values = [ this.ctrl.filterOnKeyword ], this.constructFiltersFromModel());
+            this.ctrl.keywordFilter.values = [ this.ctrl.filterOnKeyword ], this.constructFiltersFromModel()), 
+            e.vendors && e.vendors.currentValue && (i.isEmpty(this.ctrl.vendors) || (this.ctrl.VendorFilter ? this.ctrl.VendorFilter.values = this.getVendorValues(this.ctrl.vendors) : (this.ctrl.VendorFilter = {
+                id: "vendors",
+                title: "Publisher",
+                filterType: "checkbox",
+                values: this.getVendorValues(this.ctrl.vendors)
+            }, this.ctrl.filterPanelModel.push(this.ctrl.VendorFilter))));
         }, e.prototype.$onDestroy = function() {
             this.removeClearFilterListener();
+        }, e.prototype.getVendorValues = function(e) {
+            return i.map(e, function(e) {
+                return {
+                    id: e,
+                    title: e,
+                    value: e,
+                    selected: !1
+                };
+            });
         }, e.prototype.createAppliedFilter = function(e, t) {
             return {
                 id: e.id,
@@ -2072,7 +2083,8 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             }, this.ctrl.keywordFilter && this.setKeywordFilter(this.ctrl.keywordFilter);
         }, e.prototype.$onChanges = function(e) {
             e.catalogItems && e.catalogItems.currentValue && (this.ctrl.isEmpty = n.isEmpty(this.ctrl.catalogItems), 
-            this.ctrl.isEmpty || (this.ctrl.categories = this.catalog.categories, this.filterByCategory("all", "all", !0)), 
+            this.ctrl.isEmpty || (this.ctrl.categories = this.catalog.categorizeItems(this.ctrl.catalogItems), 
+            this.ctrl.vendors = this.catalog.getVendors(this.ctrl.catalogItems), this.filterByCategory("all", "all", !0)), 
             this.ctrl.loaded = !0), e.keywordFilter && !e.keywordFilter.isFirstChange() && this.setKeywordFilter(this.ctrl.keywordFilter);
         }, e.prototype.$postLink = function() {
             this.scrollParent = this.getScrollParent(this.element), this.scrollParent && this.htmlService.isWindowAboveBreakpoint(this.htmlService.WINDOW_SIZE_SM) && (this.ctrl.viewStyle = {

--- a/src/components/catalog-filter/catalog-filter.component.ts
+++ b/src/components/catalog-filter/catalog-filter.component.ts
@@ -3,6 +3,7 @@ import {CatalogFilterController} from './catalog-filter.controller';
 export const catalogFilter: angular.IComponentOptions = {
   bindings: {
     config: '<',
+    vendors: '<',
     filterOnKeyword: '<',
     applyFilters: "&"
   },

--- a/src/components/catalog-filter/catalog-filter.controller.ts
+++ b/src/components/catalog-filter/catalog-filter.controller.ts
@@ -12,41 +12,24 @@ export class CatalogFilterController implements angular.IController {
   constructor($scope: any, Catalog: any) {
     this.$scope = $scope;
     this.Catalog = Catalog;
+
+    this.ctrl.filterPanelModel = [];
+    this.ctrl.keywordFilter = {
+      id: 'keyword',
+      title:  'Keyword',
+      placeholder: 'Filter by Keyword',
+      filterType: 'text',
+      values: []
+    };
+    this.ctrl.filterPanelModel.push(this.ctrl.keywordFilter);
   }
 
   public $onInit() {
-    this.ctrl.filterPanelModel = [];
-    this.ctrl.keywordFilter = {
-        id: 'keyword',
-        title:  'Keyword',
-        placeholder: 'Filter by Keyword',
-        filterType: 'text',
-        values: []
-      };
-    this.ctrl.filterPanelModel.push(this.ctrl.keywordFilter);
-
-    if (!_.isEmpty(this.Catalog.vendors)) {
-      this.ctrl.VendorFilter = {
-        id: 'vendors',
-        title: 'Publisher',
-        filterType: 'checkbox',
-        values: _.map(this.Catalog.vendors, (vendor) => {
-          return {
-            id: vendor,
-            title: vendor,
-            value: vendor,
-            selected: false
-          };
-        })
-      };
-      this.ctrl.filterPanelModel.push(this.ctrl.VendorFilter);
-    }
 
     if (this.ctrl.filterOnKeyword) {
       this.ctrl.keywordFilter.values = [this.ctrl.filterOnKeyword];
       this.constructFiltersFromModel();
     }
-
     this.ctrl.config.onFilterChange = this.onFilterChange;
 
     this.removeClearFilterListener = this.$scope.$on('clear-filters', () => {
@@ -60,6 +43,21 @@ export class CatalogFilterController implements angular.IController {
       this.resetFilterPanelModel();
       this.ctrl.keywordFilter.values = [this.ctrl.filterOnKeyword];
       this.constructFiltersFromModel();
+    }
+    if (onChangesObj.vendors  && onChangesObj.vendors.currentValue) {
+      if (!_.isEmpty(this.ctrl.vendors)) {
+        if (!this.ctrl.VendorFilter) {
+          this.ctrl.VendorFilter = {
+            id: 'vendors',
+            title: 'Publisher',
+            filterType: 'checkbox',
+            values: this.getVendorValues(this.ctrl.vendors)
+          };
+          this.ctrl.filterPanelModel.push(this.ctrl.VendorFilter);
+        } else {
+          this.ctrl.VendorFilter.values = this.getVendorValues(this.ctrl.vendors);
+        }
+      }
     }
   }
 
@@ -80,6 +78,17 @@ export class CatalogFilterController implements angular.IController {
   // called when filter is changed in the filter panel
   public filterChanged = () => {
     this.constructFiltersFromModel();
+  };
+
+  private getVendorValues (vendors: any) {
+    return _.map(vendors, (vendor) => {
+      return {
+        id: vendor,
+        title: vendor,
+        value: vendor,
+        selected: false
+      };
+    });
   };
 
   // called when filter cleared by hitting 'x' in filter results tag, or 'Clear All Filters' link

--- a/src/components/services-view/services-view.controller.ts
+++ b/src/components/services-view/services-view.controller.ts
@@ -80,7 +80,8 @@ export class ServicesViewController implements angular.IController {
     if (onChangesObj.catalogItems && onChangesObj.catalogItems.currentValue) {
       this.ctrl.isEmpty = _.isEmpty(this.ctrl.catalogItems);
       if (!this.ctrl.isEmpty) {
-        this.ctrl.categories = this.catalog.categories;
+        this.ctrl.categories = this.catalog.categorizeItems(this.ctrl.catalogItems);
+        this.ctrl.vendors = this.catalog.getVendors(this.ctrl.catalogItems);
         this.filterByCategory('all', 'all', true);
       }
       this.ctrl.loaded = true;

--- a/src/components/services-view/services-view.html
+++ b/src/components/services-view/services-view.html
@@ -72,6 +72,7 @@
           <div ng-if="$ctrl.currentSubFilter === subCategory.id" class="services-items">
             <catalog-filter class="services-items-filter"
                             config="$ctrl.filterConfig"
+                            vendors="$ctrl.vendors"
                             filter-on-keyword="$ctrl.keywordFilterValue"
                             apply-filters="$ctrl.applyFilters($event)">
             </catalog-filter>
@@ -100,6 +101,7 @@
           <catalog-filter ng-if="!$ctrl.isEmpty"
                           class="services-items-filter"
                           config="$ctrl.filterConfig"
+                          vendors="$ctrl.vendors"
                           filter-on-keyword="$ctrl.keywordFilterValue"
                           apply-filters="$ctrl.applyFilters($event)">
           </catalog-filter>


### PR DESCRIPTION
Remove the determination of categories and vendors from the calls to get catalog items (either project or all). Rather, add methods to determine and return these based on a list of catalog items.

Fixes #586 