### PR TITLE
Don't assume image stream is from openshift namespace

### DIFF
--- a/dist/origin-web-catalogs.js
+++ b/dist/origin-web-catalogs.js
@@ -1410,9 +1410,9 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
                 t && a.push(t);
             }), a;
         }, e.prototype.getImageStreamTag = function() {
-            var e = this.ctrl.imageStream.resource.metadata.name + ":" + this.ctrl.istag.name, t = this.APIService.getPreferredVersion("imagestreamtags");
-            return this.DataService.get(t, e, {
-                namespace: "openshift"
+            var e = this.APIService.getPreferredVersion("imagestreamtags"), t = this.ctrl.imageStream.resource.metadata.name + ":" + this.ctrl.istag.name, r = this.ctrl.imageStream.resource.metadata.namespace;
+            return this.DataService.get(e, t, {
+                namespace: r
             });
         }, e.prototype.sortServiceInstances = function() {
             if (this.ctrl.serviceInstances) {

--- a/src/components/create-from-builder/create-from-builder.controller.ts
+++ b/src/components/create-from-builder/create-from-builder.controller.ts
@@ -338,9 +338,12 @@ export class CreateFromBuilderController implements angular.IController {
   }
 
   private getImageStreamTag() {
-    let name = this.ctrl.imageStream.resource.metadata.name + ":" + this.ctrl.istag.name;
     let imageStreamTagsVersion = this.APIService.getPreferredVersion('imagestreamtags');
-    return this.DataService.get(imageStreamTagsVersion, name, { namespace: 'openshift' });
+    let name = this.ctrl.imageStream.resource.metadata.name + ":" + this.ctrl.istag.name;
+    let namespace = this.ctrl.imageStream.resource.metadata.namespace;
+    return this.DataService.get(imageStreamTagsVersion, name, {
+      namespace: namespace
+    });
   }
 
   private sortServiceInstances() {


### PR DESCRIPTION
In the create from builder dialog, handle image streams that are from namespaces other than `openshift`.

https://github.com/openshift/origin-web-console/pull/2563 lets you use builders from another namespace.

/kind bug
/assign @jwforres 
/cc @jwforres @jeff-phillips-18 