### PR TITLE
fix(overlay-panel): Fix overlay-panel escape key event handler.

### DIFF
--- a/dist/origin-web-catalogs.js
+++ b/dist/origin-web-catalogs.js
@@ -1771,13 +1771,13 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             this.ctrl = this, this.closePanel = function() {
                 n.isFunction(r.ctrl.handleClose) && r.ctrl.handleClose();
             }, this.showDialog = function() {
-                r.ctrl.shown = !0, i("body").addClass("overlay-open"), r.$document.bind("keydown keypress", r.closeOnEsc);
+                r.ctrl.shown = !0, i("body").addClass("overlay-open"), r.$document.on("keydown", r.closeOnEsc);
             }, this.hideDialog = function() {
-                r.ctrl.shown = !1, i("body").removeClass("overlay-open"), r.$document.unbind("keydown keypress", r.closeOnEsc);
+                r.ctrl.shown = !1, i("body").removeClass("overlay-open"), r.$document.off("keydown", r.closeOnEsc);
             }, this.closeOnEsc = function(e) {
-                27 === e.which && (e.preventDefault(), r.$scope.$evalAsync(function() {
+                27 === e.which && (e.isDefaultPrevented() || (e.preventDefault(), r.$scope.$evalAsync(function() {
                     r.closePanel();
-                }));
+                })));
             }, this.$document = e, this.$scope = t, this.ctrl.shown = !1;
         }
         return e.prototype.$postLink = function() {

--- a/src/components/overlay-panel/overlay-panel.controller.ts
+++ b/src/components/overlay-panel/overlay-panel.controller.ts
@@ -43,21 +43,26 @@ export class OverlayPanelController implements angular.IController {
   private showDialog = () => {
     this.ctrl.shown = true;
     $('body').addClass('overlay-open');
-    this.$document.bind('keydown keypress', this.closeOnEsc);
+    this.$document.on('keydown', this.closeOnEsc);
   };
 
   private hideDialog = () => {
     this.ctrl.shown = false;
     $('body').removeClass('overlay-open');
-    this.$document.unbind('keydown keypress', this.closeOnEsc);
+    this.$document.off('keydown', this.closeOnEsc);
   };
 
   private closeOnEsc = (event: any) => {
     if (event.which === 27) {
-      event.preventDefault();
-      this.$scope.$evalAsync(() => {
-        this.closePanel();
-      });
+      // Only close this overlay if another handler has not called 
+      // preventDefault() on this event. This means only one overlay/modal will
+      // be closed per escape keydown event.
+      if (!event.isDefaultPrevented()) {
+        event.preventDefault();
+        this.$scope.$evalAsync(() => {
+          this.closePanel();
+        });
+      }
     }
   };
 }


### PR DESCRIPTION
## Description
Remove `keypress` event binding from overlay panel controller and add a check in `keydown` event handler to ensure preventDefault() has not already been called on the event. This ensures that if another handler has already handled the escape keydown event and explicitly prevented default behavior, then the overlay panel will not be dismissed.

Fixes #604

/kind bug