### PR TITLE
Fix bug where landing search obscures primary nav at mobile

### DIFF
--- a/app/app.less
+++ b/app/app.less
@@ -29,16 +29,6 @@
 }
 
 .showcase-app {
-  .catalog-search, .landing-side-bar {
-    @media (min-width: @screen-sm-min) {
-      top: @navbar-height;
-    }
-  }
-  .landing {
-    @media (min-width: @screen-sm-min) {
-      top: @landing-offset-top;
-    }
-  }
   .navbar-brand {
     cursor: default;
     &:hover, &:focus {
@@ -47,7 +37,7 @@
   }
   .navbar-header {
     height: @navbar-height - 3px;
-    padding-top: 17px
+    padding-top: 16px
   }
   .navbar-utility {
     padding-top: 17px;

--- a/app/styles/variables.less
+++ b/app/styles/variables.less
@@ -1,3 +1,1 @@
-@navbar-height: 60px;
-@landing-offset-top: (@landing-search-area-height + @navbar-height);
 @oli-font-path: "../fonts";

--- a/dist/less/landing-page.less
+++ b/dist/less/landing-page.less
@@ -4,9 +4,7 @@
   background-size: @landing-bg-size;
   border-bottom: solid 1px @search-area-border;
   padding: (@grid-gutter-width / 4) (@grid-gutter-width / 2);
-  position: relative;
   width: 100%;
-  z-index: @zindex-navbar-fixed - 1;
   @media (max-width: @screen-xs-max) {
     .ios & {
       background-size: @landing-bg-size-ios-phone;
@@ -82,16 +80,19 @@
       text-align: center;
     }
   }
-  .search-pf .has-clear .clear {
-    height: 29px;
-  }
-  .search-pf-input-group {
-    .form-control {
-      font-size: (@font-size-base + 2);
-      height: 2.2em;
+  .landing-search-area & {
+    z-index: @zindex-navbar-fixed - 1;
+    .search-pf .has-clear .clear {
+      height: 28px;
     }
-    .pficon-close {
-      font-size: (@font-size-base + 4);
+    .search-pf-input-group {
+      .form-control {
+        font-size: (@font-size-base + 2);
+        height: 30px;
+      }
+      .pficon-close {
+        font-size: (@font-size-base + 4);
+      }
     }
   }
 }

--- a/dist/less/variables.less
+++ b/dist/less/variables.less
@@ -7,15 +7,15 @@
 @landing-bg-size-ios-phone:                           auto;
 @landing-main-bg:                                     #3ca2c9;
 @landing-offset-top:                                  (@landing-search-area-height + @navbar-height);
-@landing-search-area-height:                          52px;
+@landing-search-area-height:                          51px;
 @landing-side-bar-bg:                                 @color-pf-black-900;
 @landing-side-bar-link-color:                         @color-pf-blue-300;
 @landing-side-bar-link-color-hover:                   lighten(@landing-side-bar-link-color, 10%);
-@landing-side-bar-top-offset:                         72px;
+@landing-side-bar-top-offset:                         @navbar-height;
 @landing-side-bar-width-lg:                           425px;
 @landing-side-bar-width-sm:                           325px;
 @landing-side-bar-width-xl:                           475px;
-@navbar-height:                                       72px;
+@navbar-height:                                       61px;
 @order-service-page-height:                           410px;
 @order-service-title-sm-min:                          450px;
 @saas-hover:                                          fade(@color-pf-blue-700, 35%);

--- a/dist/origin-web-catalogs.css
+++ b/dist/origin-web-catalogs.css
@@ -51,9 +51,7 @@
   background-size: cover;
   border-bottom: solid 1px rgba(0, 34, 53, 0.6);
   padding: 10px 20px;
-  position: relative;
   width: 100%;
-  z-index: 1029;
 }
 @media (max-width: 767px) {
   .ios .catalog-search {
@@ -63,7 +61,7 @@
 @media (min-width: 768px) {
   .catalog-search {
     position: fixed;
-    top: 72px;
+    top: 61px;
     width: calc(100% - 325px);
   }
 }
@@ -135,14 +133,17 @@
   padding: 5px 0;
   text-align: center;
 }
-.catalog-search .search-pf .has-clear .clear {
-  height: 29px;
+.landing-search-area .catalog-search {
+  z-index: 1029;
 }
-.catalog-search .search-pf-input-group .form-control {
+.landing-search-area .catalog-search .search-pf .has-clear .clear {
+  height: 28px;
+}
+.landing-search-area .catalog-search .search-pf-input-group .form-control {
   font-size: 14px;
-  height: 2.2em;
+  height: 30px;
 }
-.catalog-search .search-pf-input-group .pficon-close {
+.landing-search-area .catalog-search .search-pf-input-group .pficon-close {
   font-size: 16px;
 }
 @media only screen and (max-device-width: 736px) and (-webkit-min-device-pixel-ratio: 0) {
@@ -199,7 +200,7 @@
     overflow-x: hidden;
     overflow-y: auto;
     position: absolute;
-    top: 124px;
+    top: 112px;
     width: calc(100% - 325px);
   }
 }
@@ -245,7 +246,7 @@ landingbody,
     overflow-y: auto;
     position: fixed;
     right: 0;
-    top: 72px;
+    top: 61px;
     width: 325px;
   }
 }

--- a/src/styles/landing-page.less
+++ b/src/styles/landing-page.less
@@ -4,9 +4,7 @@
   background-size: @landing-bg-size;
   border-bottom: solid 1px @search-area-border;
   padding: (@grid-gutter-width / 4) (@grid-gutter-width / 2);
-  position: relative;
   width: 100%;
-  z-index: @zindex-navbar-fixed - 1;
   @media (max-width: @screen-xs-max) {
     .ios & {
       background-size: @landing-bg-size-ios-phone;
@@ -82,16 +80,19 @@
       text-align: center;
     }
   }
-  .search-pf .has-clear .clear {
-    height: 29px;
-  }
-  .search-pf-input-group {
-    .form-control {
-      font-size: (@font-size-base + 2);
-      height: 2.2em;
+  .landing-search-area & {
+    z-index: @zindex-navbar-fixed - 1;
+    .search-pf .has-clear .clear {
+      height: 28px;
     }
-    .pficon-close {
-      font-size: (@font-size-base + 4);
+    .search-pf-input-group {
+      .form-control {
+        font-size: (@font-size-base + 2);
+        height: 30px;
+      }
+      .pficon-close {
+        font-size: (@font-size-base + 4);
+      }
     }
   }
 }

--- a/src/styles/variables.less
+++ b/src/styles/variables.less
@@ -7,15 +7,15 @@
 @landing-bg-size-ios-phone:                           auto;
 @landing-main-bg:                                     #3ca2c9;
 @landing-offset-top:                                  (@landing-search-area-height + @navbar-height);
-@landing-search-area-height:                          52px;
+@landing-search-area-height:                          51px;
 @landing-side-bar-bg:                                 @color-pf-black-900;
 @landing-side-bar-link-color:                         @color-pf-blue-300;
 @landing-side-bar-link-color-hover:                   lighten(@landing-side-bar-link-color, 10%);
-@landing-side-bar-top-offset:                         72px;
+@landing-side-bar-top-offset:                         @navbar-height;
 @landing-side-bar-width-lg:                           425px;
 @landing-side-bar-width-sm:                           325px;
 @landing-side-bar-width-xl:                           475px;
-@navbar-height:                                       72px;
+@navbar-height:                                       61px;
 @order-service-page-height:                           410px;
 @order-service-title-sm-min:                          450px;
 @saas-hover:                                          fade(@color-pf-blue-700, 35%);


### PR DESCRIPTION
Supports https://github.com/openshift/origin-web-console/issues/2701

![screen shot 2018-01-23 at 1 28 32 pm](https://user-images.githubusercontent.com/895728/35293314-55ce45e8-0041-11e8-918d-1648dc806507.PNG)

And additional search-related cleanup:

* remove redundant and incorrect landing positioning rules
* fix bug where project picker was masked by search input at mobile [1]

[1] 
Before:
![screen shot 2018-01-23 at 1 18 13 pm](https://user-images.githubusercontent.com/895728/35293234-1b1bf026-0041-11e8-9e31-d76e5cc4caef.PNG)

After:
![screen shot 2018-01-23 at 1 18 32 pm](https://user-images.githubusercontent.com/895728/35293237-1ee82f1c-0041-11e8-89d9-081a4d368871.PNG)


