### PR TITLE
Catalog Filter: prevent duplicate keyword filters

### DIFF
--- a/dist/less/animations.less
+++ b/dist/less/animations.less
@@ -1,3 +1,8 @@
+@keyframes flash {
+  0% { opacity: 0; }
+  100% { opacity: 1; }
+}
+
 @keyframes modalBackdropIn {
   0% {
     opacity: 0;

--- a/dist/less/services-view.less
+++ b/dist/less/services-view.less
@@ -17,6 +17,9 @@ services-view,
   .filter-panel-container ul {
     margin-bottom: 10px;
   }
+  .flash-filter-tag{
+    animation: flash linear 1s 1;
+  }
   .pf-empty-state {
     margin: 0 (@grid-gutter-width / 2);
     width: 100%;

--- a/dist/origin-web-catalogs.css
+++ b/dist/origin-web-catalogs.css
@@ -9,6 +9,14 @@
   word-break: break-word;
   overflow-wrap: break-word;
 }
+@keyframes flash {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
 @keyframes modalBackdropIn {
   0% {
     opacity: 0;
@@ -1082,6 +1090,9 @@ services-view .vendor-info-icon,
 }
 .services-view .filter-panel-container ul {
   margin-bottom: 10px;
+}
+.services-view .flash-filter-tag {
+  animation: flash linear 1s 1;
 }
 .services-view .pf-empty-state {
   margin: 0 20px;

--- a/dist/origin-web-catalogs.js
+++ b/dist/origin-web-catalogs.js
@@ -385,11 +385,11 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             } ]
         } ];
         n.set(window, "OPENSHIFT_CONSTANTS.SERVICE_CATALOG_CATEGORIES", s), n.set(window, "OPENSHIFT_CONSTANTS.SAAS_OFFERINGS", a);
-        var c = {
+        var o = {
             pod_presets: !1
         };
-        n.set(window, "OPENSHIFT_CONSTANTS.ENABLE_TECH_PREVIEW_FEATURE", c);
-        var o = {
+        n.set(window, "OPENSHIFT_CONSTANTS.ENABLE_TECH_PREVIEW_FEATURE", o);
+        var c = {
             links: [ {
                 title: "Documentation",
                 help: ""
@@ -407,7 +407,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
                 href: "https://blog.openshift.com"
             } ]
         };
-        n.set(window, "OPENSHIFT_CONSTANTS.CATALOG_HELP_RESOURCES", o);
+        n.set(window, "OPENSHIFT_CONSTANTS.CATALOG_HELP_RESOURCES", c);
         var l = function() {
             e("body").find(".services-view-container .nav-tabs a")[0].click();
         }, d = function() {
@@ -694,17 +694,17 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             this.logger = a;
         }
         return e.prototype.getCatalogItems = function(e) {
-            var t = this, r = this.$q.defer(), n = {}, a = 0, s = 0, c = [], o = this.apiService.getPreferredVersion("clusterserviceclasses");
-            this.apiService.apiInfo(o) && (++a, this.dataService.list(o, {}).then(function(e) {
+            var t = this, r = this.$q.defer(), n = {}, a = 0, s = 0, o = [], c = this.apiService.getPreferredVersion("clusterserviceclasses");
+            this.apiService.apiInfo(c) && (++a, this.dataService.list(c, {}).then(function(e) {
                 n.serviceClasses = i.reject(e.by("metadata.name"), {
                     status: {
                         removedFromBrokerCatalog: !0
                     }
                 });
             }, function() {
-                c.push("service classes");
+                o.push("service classes");
             }).finally(function() {
-                t.returnCatalogItems(r, n, ++s, a, c);
+                t.returnCatalogItems(r, n, ++s, a, o);
             })), ++a;
             var l = this.apiService.getPreferredVersion("imagestreams");
             if (this.dataService.list(l, {
@@ -712,9 +712,9 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             }).then(function(e) {
                 n.imageStreams = e.by("metadata.name");
             }, function() {
-                c.push("builder images");
+                o.push("builder images");
             }).finally(function() {
-                t.returnCatalogItems(r, n, ++s, a, c);
+                t.returnCatalogItems(r, n, ++s, a, o);
             }), e) {
                 ++a;
                 var d = this.apiService.getPreferredVersion("templates");
@@ -725,9 +725,9 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
                 }).then(function(e) {
                     n.templates = e.by("metadata.name");
                 }, function() {
-                    c.push("templates");
+                    o.push("templates");
                 }).finally(function() {
-                    t.returnCatalogItems(r, n, ++s, a, c);
+                    t.returnCatalogItems(r, n, ++s, a, o);
                 });
             }
             return r.promise;
@@ -755,16 +755,16 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             var a = this.$q.defer(), s = {
                 imageStreams: [],
                 templates: []
-            }, c = 0, o = 0, l = [], d = this.apiService.getPreferredVersion("imagestreams"), p = this.apiService.getPreferredVersion("templates");
-            return t && (c++, this.dataService.list(d, {
+            }, o = 0, c = 0, l = [], d = this.apiService.getPreferredVersion("imagestreams"), p = this.apiService.getPreferredVersion("templates");
+            return t && (o++, this.dataService.list(d, {
                 namespace: e
             }).then(function(e) {
                 s.imageStreams = e.by("metadata.name");
             }, function() {
                 l.push("builder images");
             }).finally(function() {
-                i.returnCatalogItems(a, s, ++o, c, l);
-            })), r && (c++, this.dataService.list(p, {
+                i.returnCatalogItems(a, s, ++c, o, l);
+            })), r && (o++, this.dataService.list(p, {
                 namespace: e
             }, null, {
                 partialObjectMetadataList: n
@@ -773,7 +773,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             }, function() {
                 l.push("templates");
             }).finally(function() {
-                i.returnCatalogItems(a, s, ++o, c, l);
+                i.returnCatalogItems(a, s, ++c, o, l);
             })), a.promise;
         }, e.prototype.sortCatalogItems = function(e) {
             return e.sort(function(e, t) {
@@ -798,9 +798,9 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
         }, e.prototype.getServiceItem = function(e) {
             return new s(e, this);
         }, e.prototype.getImageItem = function(e) {
-            return new c(e, this);
-        }, e.prototype.getTemplateItem = function(e) {
             return new o(e, this);
+        }, e.prototype.getTemplateItem = function(e) {
+            return new c(e, this);
         }, e.prototype.getPublisherSynonym = function(e) {
             return i.get(this.constants, [ "PUBLISHER_SYNONYMS", e ]) || e;
         }, e.prototype.normalizeIconClass = function(e) {
@@ -810,7 +810,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
         }, e.prototype.categorizeItems = function(e) {
             var t, r, a = this, s = n.copy(this.constants.SERVICE_CATALOG_CATEGORIES);
             this.createAllAndOtherMainCategories(s);
-            var c = i.head(s), o = i.get(c, "subCategories[0]"), l = i.last(s), d = i.get(l, "subCategories[0]");
+            var o = i.head(s), c = i.get(o, "subCategories[0]"), l = i.last(s), d = i.get(l, "subCategories[0]");
             return i.each(e, function(e) {
                 r = !1, i.each(s, function(n) {
                     n.tags ? a.hasMatchingTags(n.tags, e.tags) && (r = a.categorizeItem(e, n, "all"), 
@@ -820,7 +820,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
                     i.each(t, function(t) {
                         a.categorizeItem(e, n, t);
                     })));
-                }), r || a.categorizeItem(e, l, d), a.categorizeItem(e, c, o);
+                }), r || a.categorizeItem(e, l, d), a.categorizeItem(e, o, c);
             }), s;
         }, e.prototype.getVendors = function(e) {
             var t = {};
@@ -912,7 +912,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
         }, e;
     }();
     t.ServiceItem = s;
-    var c = function() {
+    var o = function() {
         function e(e, t) {
             this.resource = e, this.catalogSrv = t, this.builderSpecTagName = this.getBuilderSpecTagName(), 
             this.builderSpecTagName ? (this.tags = this.getTags(), this.imageUrl = this.getImage(), 
@@ -948,8 +948,8 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             return null;
         }, e;
     }();
-    t.ImageItem = c;
-    var o = function() {
+    t.ImageItem = o;
+    var c = function() {
         function e(e, t) {
             this.resource = e, this.catalogSrv = t, this.imageUrl = this.getImage(), this.iconClass = this.getIcon(), 
             this.name = this.getName(), this.description = this.getDescription(), this.longDescription = this.getLongDescription(), 
@@ -975,7 +975,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             return this.catalogSrv.getPublisherSynonym(e);
         }, e;
     }();
-    t.TemplateItem = o;
+    t.TemplateItem = c;
 }, function(e, t, r) {
     "use strict";
     t.__esModule = !0;
@@ -1026,17 +1026,34 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
     "use strict";
     t.__esModule = !0;
     var n = r(1), i = r(0), a = function() {
-        function e(e, t) {
-            var r = this;
+        function e(e, t, r) {
+            var a = this;
             this.ctrl = this, this.onKeywordKeyPress = function(e) {
-                13 === e.which && r.ctrl.keywordFilter.value.length > 0 && (r.ctrl.keywordFilter.values.push(r.ctrl.keywordFilter.value), 
-                delete r.ctrl.keywordFilter.value, r.constructFiltersFromModel());
+                if (13 === e.which && a.ctrl.keywordFilter.value.length > 0) {
+                    var t = a.ctrl.keywordFilter.value;
+                    a.keywordFilterExists(t) ? a.highlightKeywordFilter(t) : (a.ctrl.keywordFilter.values.push(t), 
+                    a.constructFiltersFromModel()), delete a.ctrl.keywordFilter.value;
+                }
             }, this.filterChanged = function() {
-                r.constructFiltersFromModel();
-            }, this.onFilterChange = function(e, t, i) {
-                n.isDefined(t) && n.isDefined(i) ? r.updateFilterPanelModel(t, i) : r.resetFilterPanelModel(), 
-                r.constructFiltersFromModel();
-            }, this.$scope = e, this.Catalog = t, this.ctrl.filterPanelModel = [], this.ctrl.keywordFilter = {
+                a.constructFiltersFromModel();
+            }, this.keywordFilterExists = function(e) {
+                return i.some(a.ctrl.keywordFilter.values, function(t) {
+                    return e.toLowerCase() === t.toLowerCase();
+                });
+            }, this.highlightKeywordFilter = function(e) {
+                var t = document.querySelectorAll(".active-filter.label.label-info.single-label"), r = i.find(t, function(t) {
+                    return t.innerText.trim() === "Keyword: " + e.toLowerCase();
+                });
+                r && (a.$timeout(function() {
+                    r.classList.add("flash-filter-tag");
+                }, 100), a.$timeout(function() {
+                    r.classList.remove("flash-filter-tag");
+                }, 300));
+            }, this.onFilterChange = function(e, t, r) {
+                n.isDefined(t) && n.isDefined(r) ? a.updateFilterPanelModel(t, r) : a.resetFilterPanelModel(), 
+                a.constructFiltersFromModel();
+            }, this.$scope = e, this.$timeout = t, this.Catalog = r, this.ctrl.filterPanelModel = [], 
+            this.ctrl.keywordFilter = {
                 id: "keyword",
                 title: "Keyword",
                 placeholder: "Filter by Keyword",
@@ -1125,7 +1142,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             });
         }, e;
     }();
-    a.$inject = [ "$scope", "Catalog" ], t.CatalogFilterController = a;
+    a.$inject = [ "$scope", "$timeout", "Catalog" ], t.CatalogFilterController = a;
 }, function(e, t, r) {
     "use strict";
     t.__esModule = !0;
@@ -1267,7 +1284,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
     "use strict";
     t.__esModule = !0;
     var n = r(1), i = r(0), a = r(69), s = function() {
-        function e(e, t, r, n, a, s, c, o, l, d, p) {
+        function e(e, t, r, n, a, s, o, c, l, d, p) {
             var h = this;
             this.ctrl = this, this.watches = [], this.clearValidityWatcher = function() {
                 h.validityWatcher && (h.validityWatcher(), h.validityWatcher = void 0);
@@ -1303,7 +1320,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
                 var t, r = h.BindingService.getServiceClassForInstance(e, h.ctrl.serviceClasses), n = i.get(e, "spec.clusterServicePlanRef.name");
                 return n && (t = h.ctrl.servicePlans[n]), h.BindingService.isServiceBindable(e, r, t);
             }, this.$scope = e, this.$filter = t, this.$location = r, this.$q = n, this.BuilderAppService = a, 
-            this.ProjectsService = s, this.DataService = c, this.APIService = o, this.BindingService = l, 
+            this.ProjectsService = s, this.DataService = o, this.APIService = c, this.BindingService = l, 
             this.Logger = d, this.ctrl.serviceToBind = null, this.ctrl.showPodPresets = i.get(p, [ "ENABLE_TECH_PREVIEW_FEATURE", "pod_presets" ], !1), 
             this.gitRef = "", this.contextDir = "";
         }
@@ -1404,8 +1421,8 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
                 var a = e.getTagReference(n);
                 if (a) return t[n.name] = a, e.ctrl.referencedBy[a] = e.ctrl.referencedBy[a] || [], 
                 void e.ctrl.referencedBy[a].push(n.name);
-                var s = i.get(n, "annotations.tags", ""), c = s.split(/\s*,\s*/);
-                i.includes(c, "builder") && !i.includes(c, "hidden") && (r[n.name] = n);
+                var s = i.get(n, "annotations.tags", ""), o = s.split(/\s*,\s*/);
+                i.includes(o, "builder") && !i.includes(o, "hidden") && (r[n.name] = n);
             });
             var a = [], s = i.get(this, "ctrl.imageStream.resource.status.tags", []);
             return i.each(s, function(e) {
@@ -1534,7 +1551,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
     "use strict";
     t.__esModule = !0;
     var n = r(1), i = r(0), a = function() {
-        function e(e, t, r, n, a, s, c, o, l, d) {
+        function e(e, t, r, n, a, s, o, c, l, d) {
             var p = this;
             this.ctrl = this, this.watches = [], this.clearValidityWatcher = function() {
                 p.validityWatcher && (p.validityWatcher(), p.validityWatcher = void 0), p.ctrl.reviewStep.allowed = !1;
@@ -1598,7 +1615,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
                     });
                 }));
             }, this.$scope = e, this.$filter = t, this.APIService = r, this.ApplicationsService = n, 
-            this.ProjectsService = a, this.DataService = s, this.BindingService = c, this.Logger = o, 
+            this.ProjectsService = a, this.DataService = s, this.BindingService = o, this.Logger = c, 
             this.ctrl.showPodPresets = i.get(l, [ "ENABLE_TECH_PREVIEW_FEATURE", "pod_presets" ], !1), 
             this.DNS1123_SUBDOMAIN_VALIDATION = d;
         }
@@ -1690,8 +1707,8 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             this.DataService.create(a, null, n, s).then(function(n) {
                 if (e.ctrl.orderInProgress = !0, e.watchResults(a, n, s), e.ctrl.serviceInstance = n, 
                 r) {
-                    var c = e.BindingService.makeParametersSecret(r, t, n), o = e.APIService.getPreferredVersion("secrets");
-                    e.DataService.create(o, null, c, s).then(i.noop, function(t) {
+                    var o = e.BindingService.makeParametersSecret(r, t, n), c = e.APIService.getPreferredVersion("secrets");
+                    e.DataService.create(c, null, o, s).then(i.noop, function(t) {
                         e.ctrl.error = i.get(t, "data");
                     });
                 }
@@ -1793,7 +1810,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
     "use strict";
     t.__esModule = !0;
     var n = r(1), i = r(0), a = function() {
-        function e(t, r, a, s, c, o, l, d, p, h, m) {
+        function e(t, r, a, s, o, c, l, d, p, h, m) {
             var u = this;
             this.ctrl = this, this.newProjectPanelShown = !1, this.editProjectPanelShown = !1, 
             this.watches = [], this.maxDisplayProjects = 5, this.watchingProjects = !1, this.init = function() {
@@ -1831,8 +1848,8 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
                 u.ctrl.editProjectPanelShown = !1, u.watchingProjects || u.ProjectsService.list().then(u.onProjectsUpdate);
             }, this.onDeleteProject = function() {
                 u.watchingProjects || u.ProjectsService.list().then(u.onProjectsUpdate);
-            }, this.$filter = t, this.$rootScope = r, this.$scope = a, this.$window = s, this.AuthService = c, 
-            this.Constants = o, this.DataService = l, this.Logger = d, this.ProjectsService = p, 
+            }, this.$filter = t, this.$rootScope = r, this.$scope = a, this.$window = s, this.AuthService = o, 
+            this.Constants = c, this.DataService = l, this.Logger = d, this.ProjectsService = p, 
             this.RecentlyViewedProjectsService = h, this.RecentlyViewedItems = m;
         }
         return e.prototype.$onInit = function() {
@@ -1942,7 +1959,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
     "use strict";
     t.__esModule = !0;
     var n = r(1), i = r(0), a = function() {
-        function e(t, r, n, a, s, c, o, l) {
+        function e(t, r, n, a, s, o, c, l) {
             var d = this;
             this.ctrl = this, this.getProjectChoices = function() {
                 return d.ctrl.matchingProjects ? d.ctrl.matchingProjects : d.largeProjectList ? [] : d.projects;
@@ -1958,7 +1975,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
                     e = d.AuthorizationService.canIAddToProject(t), d.ctrl.forms && d.ctrl.forms.selectProjectForm.selectProject.$setValidity("cannotAddToProject", e);
                 }), d.ctrl.forms && d.ctrl.forms.selectProjectForm.selectProject.$setValidity("cannotAddToProject", e);
             }, this.$filter = t, this.$scope = r, this.AuthService = n, this.AuthorizationService = a, 
-            this.KeywordService = s, this.Logger = c, this.ProjectsService = o, this.RecentlyViewedProjectsService = l, 
+            this.KeywordService = s, this.Logger = o, this.ProjectsService = c, this.RecentlyViewedProjectsService = l, 
             this.largeProjectList = !1, this.lastSearch = "", this.lastResults = [];
         }
         return e.prototype.$onInit = function() {
@@ -2041,7 +2058,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
     "use strict";
     t.__esModule = !0;
     var n = r(0), i = r(2), a = function() {
-        function e(e, t, r, i, a, s, c, o, l, d) {
+        function e(e, t, r, i, a, s, o, c, l, d) {
             var p = this;
             this.ctrl = this, this.previousSubCategoryHeight = 0, this.resizeRetries = 0, this.serviceViewItemClicked = function(e, t) {
                 p.$scope.$emit("open-overlay-panel", e);
@@ -2059,7 +2076,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             }, this.clearAppliedFilters = function() {
                 p.$scope.$broadcast("clear-filters");
             }, this.constants = e, this.catalog = t, this.keywordService = r, this.logger = i, 
-            this.htmlService = a, this.element = s[0], this.$filter = c, this.$rootScope = o, 
+            this.htmlService = a, this.element = s[0], this.$filter = o, this.$rootScope = c, 
             this.$scope = l, this.$timeout = d, this.ctrl.loaded = !1, this.ctrl.isEmpty = !1, 
             this.ctrl.mobileView = "categories", this.ctrl.filterConfig = {
                 resultsLabel: "Items",
@@ -2179,7 +2196,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
     "use strict";
     t.__esModule = !0;
     var n = r(1), i = r(0), a = function() {
-        function e(e, t, r, a, s, c, o, l) {
+        function e(e, t, r, a, s, o, c, l) {
             var d = this;
             this.ctrl = this, this.configChanged = !0, this.secrets = [], this.clearValidityWatcher = function() {
                 d.validityWatcher && (d.validityWatcher(), d.validityWatcher = void 0), d.ctrl.reviewStep.allowed = !1;
@@ -2207,37 +2224,37 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
                 d.ctrl.orderComplete = !1, d.ctrl.error = null;
                 var e = d.getParameters(d.ctrl.parameterData), t = i.get(d.ctrl.serviceInstance, "spec.parameters"), r = i.map(t, function(e, t) {
                     return [ t ];
-                }), a = i.pick(e, r), s = i.omit(e, r), c = n.copy(d.ctrl.serviceInstance);
-                i.get(c, "spec.clusterServicePlanExternalName") !== i.get(d.ctrl.selectedPlan, "spec.externalName") && (i.unset(c, "spec.clusterServicePlanRef"), 
-                i.set(c, "spec.clusterServicePlanExternalName", i.get(d.ctrl.selectedPlan, "spec.externalName"))), 
-                n.equals(a, t) || i.set(c, "spec.parameters", a);
-                var o = {};
+                }), a = i.pick(e, r), s = i.omit(e, r), o = n.copy(d.ctrl.serviceInstance);
+                i.get(o, "spec.clusterServicePlanExternalName") !== i.get(d.ctrl.selectedPlan, "spec.externalName") && (i.unset(o, "spec.clusterServicePlanRef"), 
+                i.set(o, "spec.clusterServicePlanExternalName", i.get(d.ctrl.selectedPlan, "spec.externalName"))), 
+                n.equals(a, t) || i.set(o, "spec.parameters", a);
+                var c = {};
                 if (i.each(d.secrets, function(t) {
                     var r = JSON.parse(d.SecretsService.decodeSecretData(t.data).parameters), a = i.map(r, function(e, t) {
                         return [ t ];
                     }), l = i.pick(e, a);
-                    s = i.omit(s, a), n.equals(l, r) || (n.extend(o, l), c.spec.parametersFrom = i.reject(c.spec.parametersFrom, {
+                    s = i.omit(s, a), n.equals(l, r) || (n.extend(c, l), o.spec.parametersFrom = i.reject(o.spec.parametersFrom, {
                         secretKeyRef: {
                             name: t.metadata.name
                         }
                     }));
-                }), n.extend(o, s), i.isEmpty(o)) d.updateServiceInstance(c); else {
+                }), n.extend(c, s), i.isEmpty(c)) d.updateServiceInstance(o); else {
                     var l = d.BindingService.generateSecretName(i.get(d.ctrl.serviceClass, "spec.externalName"));
-                    c.spec.parametersFrom.push({
+                    o.spec.parametersFrom.push({
                         secretKeyRef: {
                             name: l,
                             key: "parameters"
                         }
                     });
-                    var p = d.BindingService.makeParametersSecret(l, o, c), h = d.APIService.getPreferredVersion("secrets");
+                    var p = d.BindingService.makeParametersSecret(l, c, o), h = d.APIService.getPreferredVersion("secrets");
                     d.DataService.create(h, null, p, d.context).then(function() {
-                        d.updateServiceInstance(c);
+                        d.updateServiceInstance(o);
                     }, function(e) {
                         d.ctrl.error = i.get(e, "data");
                     });
                 }
             }, this.$scope = e, this.$filter = t, this.$q = r, this.APIService = a, this.BindingService = s, 
-            this.DataService = c, this.Logger = o, this.SecretsService = l;
+            this.DataService = o, this.Logger = c, this.SecretsService = l;
         }
         return e.prototype.$onInit = function() {
             var e = this;
@@ -2330,8 +2347,8 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
     t.__esModule = !0;
     var n = r(1);
     r(3), r(36);
-    var i = r(37), a = r(38), s = r(39), c = r(40), o = r(24), l = r(25), d = r(41), p = r(26), h = r(27), m = r(28), u = r(29), g = r(30), f = r(31), v = r(32), y = r(33), b = r(34), S = r(35), $ = r(42), P = r(23);
-    t.webCatalog = "webCatalog", n.module(t.webCatalog, [ "patternfly", "ngAnimate", "ui.bootstrap", "angularMoment", "ui.select", "schemaForm" ]).service("BuilderAppService", c.BuilderAppService).service("Catalog", d.CatalogService).service("RecentlyViewedServiceItems", $.RecentlyViewedServiceItems).filter("escapeRegExp", i.escapeRegExpFilter).filter("projectUrl", a.projectUrlFilter).filter("secretUrl", s.secretUrlFilter).component("catalogParameters", o.catalogParameters).component("catalogSearch", l.catalogSearch).component("createFromBuilder", p.createFromBuilder).component("landingPage", h.landingPage).component("orderService", m.orderService).component("overlayPanel", u.overlayPanel).component("projectsSummary", g.projectsSummary).component("saasList", f.saasList).component("selectPlan", v.selectPlan).component("selectProject", y.selectProject).component("servicesView", b.servicesView).component("updateService", S.updateService).component("catalogFilter", P.catalogFilter).run([ "$templateCache", function(e) {
+    var i = r(37), a = r(38), s = r(39), o = r(40), c = r(24), l = r(25), d = r(41), p = r(26), h = r(27), m = r(28), u = r(29), g = r(30), f = r(31), v = r(32), y = r(33), b = r(34), S = r(35), $ = r(42), P = r(23);
+    t.webCatalog = "webCatalog", n.module(t.webCatalog, [ "patternfly", "ngAnimate", "ui.bootstrap", "angularMoment", "ui.select", "schemaForm" ]).service("BuilderAppService", o.BuilderAppService).service("Catalog", d.CatalogService).service("RecentlyViewedServiceItems", $.RecentlyViewedServiceItems).filter("escapeRegExp", i.escapeRegExpFilter).filter("projectUrl", a.projectUrlFilter).filter("secretUrl", s.secretUrlFilter).component("catalogParameters", c.catalogParameters).component("catalogSearch", l.catalogSearch).component("createFromBuilder", p.createFromBuilder).component("landingPage", h.landingPage).component("orderService", m.orderService).component("overlayPanel", u.overlayPanel).component("projectsSummary", g.projectsSummary).component("saasList", f.saasList).component("selectPlan", v.selectPlan).component("selectProject", y.selectProject).component("servicesView", b.servicesView).component("updateService", S.updateService).component("catalogFilter", P.catalogFilter).run([ "$templateCache", function(e) {
         e.put("catalog-search/catalog-search-result.html", r(4)), e.put("create-from-builder/create-from-builder-info.html", r(7)), 
         e.put("create-from-builder/create-from-builder-configure.html", r(6)), e.put("create-from-builder/create-from-builder-bind.html", r(5)), 
         e.put("create-from-builder/create-from-builder-results.html", r(8)), e.put("order-service/order-service-info.html", r(12)), 

--- a/src/styles/animations.less
+++ b/src/styles/animations.less
@@ -1,3 +1,8 @@
+@keyframes flash {
+  0% { opacity: 0; }
+  100% { opacity: 1; }
+}
+
 @keyframes modalBackdropIn {
   0% {
     opacity: 0;

--- a/src/styles/services-view.less
+++ b/src/styles/services-view.less
@@ -17,6 +17,9 @@ services-view,
   .filter-panel-container ul {
     margin-bottom: 10px;
   }
+  .flash-filter-tag{
+    animation: flash linear 1s 1;
+  }
   .pf-empty-state {
     margin: 0 (@grid-gutter-width / 2);
     width: 100%;


### PR DESCRIPTION
Prevent duplicate catalog keyword filters from being applied.   Case insensitive.   Upon entering a duplicate keyword, the existing keyword filter tag/chip "flashes":

![dup-keywords](https://user-images.githubusercontent.com/12733153/35528423-c553e756-04fb-11e8-9ad4-3a8030fcbdb4.gif)

Related Issue: https://github.com/openshift/origin-web-catalog/issues/617