### PR TITLE
Catalog Filter Panel: better logic to find duplicate filter result tag to flash

### DIFF
--- a/dist/origin-web-catalogs.js
+++ b/dist/origin-web-catalogs.js
@@ -1041,8 +1041,8 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
                     return e.toLowerCase() === t.toLowerCase();
                 });
             }, this.highlightKeywordFilter = function(e) {
-                var t = document.querySelectorAll(".active-filter.label.label-info.single-label"), r = i.find(t, function(t) {
-                    return t.innerText.trim() === "Keyword: " + e.toLowerCase();
+                var t = document.querySelectorAll("pf-filter-panel-results .label-info"), r = i.find(t, function(t) {
+                    return t.innerText.trim() === "Keyword:" + e.toLowerCase();
                 });
                 r && (a.$timeout(function() {
                     r.classList.add("flash-filter-tag");

--- a/src/components/catalog-filter/catalog-filter.controller.ts
+++ b/src/components/catalog-filter/catalog-filter.controller.ts
@@ -105,10 +105,10 @@ export class CatalogFilterController implements angular.IController {
   };
 
   private highlightKeywordFilter = (keyword: string) => {
-      let filterTags: any = document.querySelectorAll('.active-filter.label.label-info.single-label');
+      let filterTags: any = document.querySelectorAll('pf-filter-panel-results .label-info');
 
       let existingKeyword: any = _.find(filterTags, (tag: any) => {
-        return tag.innerText.trim() === ("Keyword: " + keyword.toLowerCase());
+        return tag.innerText.trim() === ("Keyword:" + keyword.toLowerCase());
       });
 
       if (existingKeyword) {


### PR DESCRIPTION
So, previous iteration of this worked in the Catalog demo app., but not in Console  -I did the newbie mistake of not 'bower linking' my catalog dev code to console and making sure it actually ran in Console.  

This update makes the `querySelectorAll` more specific, while at the same time making the `_find the dup keyword filter tag/result_' matching logic more generic.