### PR TITLE
Select Project component: added ability to skip canIadd validation check

### DIFF
--- a/dist/origin-web-catalogs.js
+++ b/dist/origin-web-catalogs.js
@@ -201,6 +201,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             onOpen: "<?",
             availableProjects: "<?",
             showDivider: "<?",
+            skipCanAddValidation: "<?",
             hideCreateProject: "<?",
             hideLabel: "<?",
             isRequired: "<?"
@@ -1983,8 +1984,8 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             this.ctrl.noProjectsCantCreate = !1, this.ctrl.noProjectsConfig = {
                 title: "No Projects Found",
                 info: "Services cannot be provisioned without a project."
-            }, void 0 === this.ctrl.showDivider && (this.ctrl.showDivider = !0), void 0 === this.ctrl.isRequired && (this.ctrl.isRequired = !0), 
-            this.ProjectsService.canCreate().then(function() {
+            }, void 0 === this.ctrl.showDivider && (this.ctrl.showDivider = !0), void 0 === this.ctrl.skipCanAddValidation && (this.ctrl.skipCanAddValidation = !1), 
+            void 0 === this.ctrl.isRequired && (this.ctrl.isRequired = !0), this.ProjectsService.canCreate().then(function() {
                 e.ctrl.canCreate = !0;
             }, function(t) {
                 if (e.ctrl.canCreate = !1, 403 !== t.status) {
@@ -2005,7 +2006,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             e.nameTaken && !e.nameTaken.isFirstChange() && this.ctrl.forms.createProjectForm.name.$setValidity("nameTaken", !this.ctrl.nameTaken), 
             e.availableProjects && !e.availableProjects.isFirstChange() && this.updateProjects(this.ctrl.availableProjects);
         }, e.prototype.onSelectProjectChange = function() {
-            this.canIAddToProject(), n.isFunction(this.ctrl.onProjectSelected) && this.ctrl.onProjectSelected(this.ctrl.selectedProject);
+            this.ctrl.skipCanAddValidation || this.canIAddToProject(), n.isFunction(this.ctrl.onProjectSelected) && this.ctrl.onProjectSelected(this.ctrl.selectedProject);
         }, e.prototype.onOpenClose = function(e) {
             e && i.isFunction(this.ctrl.onOpen) && this.ctrl.onOpen();
         }, e.prototype.onNewProjectNameChange = function() {

--- a/src/components/select-project/select-project.component.ts
+++ b/src/components/select-project/select-project.component.ts
@@ -9,6 +9,7 @@ export const selectProject: angular.IComponentOptions = {
     onOpen: '<?',
     availableProjects: '<?',
     showDivider: '<?',
+    skipCanAddValidation: '<?',
     hideCreateProject: '<?',
     hideLabel: '<?',
     isRequired: '<?'

--- a/src/components/select-project/select-project.controller.ts
+++ b/src/components/select-project/select-project.controller.ts
@@ -65,6 +65,10 @@ export class SelectProjectController implements angular.IController {
       this.ctrl.showDivider = true;
     }
 
+    if (this.ctrl.skipCanAddValidation === undefined) {
+      this.ctrl.skipCanAddValidation = false;
+    }
+
     if (this.ctrl.isRequired === undefined) {
         this.ctrl.isRequired = true;
     }
@@ -111,7 +115,9 @@ export class SelectProjectController implements angular.IController {
   }
 
   public onSelectProjectChange () {
-    this.canIAddToProject();
+    if (!this.ctrl.skipCanAddValidation) {
+        this.canIAddToProject();
+    }
     if (angular.isFunction(this.ctrl.onProjectSelected)) {
       this.ctrl.onProjectSelected(this.ctrl.selectedProject);
     }


### PR DESCRIPTION
For Bugzilla:  https://bugzilla.redhat.com/show_bug.cgi?id=1540490

The `<select-project>` component lists all projects a user can view and when user selects a project, does `canIAdd` validation, typically because `<select-project>` is used in all the 'AddToProject' dlgs/wizards (deployImage, fromFile, process-template, etc..).   

When `<select-project>` is used in the Set Home Pref dlg., we do not care if user canAdd to the project, so added a param to skip this validation check.