### PR TITLE
Resolve bug where overlay wizard scrolling is sluggish

### DIFF
--- a/dist/less/overlay-panel.less
+++ b/dist/less/overlay-panel.less
@@ -66,6 +66,7 @@ body.overlay-open {
     overflow-y: auto;
     padding: 0;
     .scroll-shadows-vertical();
+    -webkit-overflow-scrolling: touch; // enable momentum scrolling in mobile Safari
     _::-webkit-full-page-media, _:future, :root & { // only target Safari
       .scroll-shadows-vertical-with-covers(65%, 0.25);
     }

--- a/dist/origin-web-catalogs.css
+++ b/dist/origin-web-catalogs.css
@@ -594,6 +594,7 @@ body.overlay-open .landing-side-bar {
   background-position: 0 0, 0 100%;
   background-repeat: no-repeat;
   background-size: 100% 6px;
+  -webkit-overflow-scrolling: touch;
 }
 .catalogs-overlay-panel .wizard-pf-main _::-webkit-full-page-media,
 .catalogs-overlay-panel .wizard-pf-main _:future,

--- a/src/styles/overlay-panel.less
+++ b/src/styles/overlay-panel.less
@@ -66,6 +66,7 @@ body.overlay-open {
     overflow-y: auto;
     padding: 0;
     .scroll-shadows-vertical();
+    -webkit-overflow-scrolling: touch; // enable momentum scrolling in mobile Safari
     _::-webkit-full-page-media, _:future, :root & { // only target Safari
       .scroll-shadows-vertical-with-covers(65%, 0.25);
     }


### PR DESCRIPTION
Supports https://github.com/openshift/origin-web-console/issues/2761

Note:  .landing and .landing-side-bar benefit from this same fix;
however, the application of the fix causes .landing-side-bar to
disappear as -webkit-overflow-scrolling: touch changes the behavior of
position: fixed.  I will work to see if I can find a workaround and
open a separate PR.