### PR TITLE
Remove scroll shadow overrides for Safari

### DIFF
--- a/dist/less/mixins.less
+++ b/dist/less/mixins.less
@@ -13,13 +13,3 @@
   background-repeat: no-repeat;
   background-size: 100% 12px;
 }
-
-.scroll-shadows-vertical-with-covers(@shadow-width: 75%, @shadow-opacity: 0.2, @shadow-cover-bg-color: rgba(255,255,255,1), @shadow-cover-bg-color-transparent: rgba(255,255,255,0)) {
-  background-attachment: local, local, scroll, scroll;
-  background-image:
-    linear-gradient(@shadow-cover-bg-color 30%, @shadow-cover-bg-color-transparent), linear-gradient(@shadow-cover-bg-color-transparent, @shadow-cover-bg-color 70%),
-    radial-gradient(ellipse at top, rgba(0, 0, 0, @shadow-opacity) 0%, rgba(0, 0, 0, 0) @shadow-width), radial-gradient(ellipse at bottom, rgba(0, 0, 0, @shadow-opacity) 0%, rgba(0, 0, 0, 0) @shadow-width);
-  background-position: 0 0, 0 100%;
-  background-repeat: no-repeat;
-  background-size: 100% 12px, 100% 12px, 100% 6px, 100% 6px;
-}

--- a/dist/less/overlay-panel.less
+++ b/dist/less/overlay-panel.less
@@ -67,9 +67,6 @@ body.overlay-open {
     padding: 0;
     .scroll-shadows-vertical();
     -webkit-overflow-scrolling: touch; // enable momentum scrolling in mobile Safari
-    _::-webkit-full-page-media, _:future, :root & { // only target Safari
-      .scroll-shadows-vertical-with-covers(65%, 0.25);
-    }
     @media(max-width: @screen-xs-max) {
       bottom: 58px; // height of .wizard-pf-footer
       height: auto;
@@ -97,9 +94,6 @@ body.overlay-open {
     min-height: 100%;
     padding: (@grid-gutter-width / 2);
     .scroll-shadows-vertical-covers();
-    _::-webkit-full-page-media, _:future, :root & { // only target Safari
-      background: none;
-    }
     @media(min-width: @screen-sm-min) {
       padding-left: @grid-gutter-width;
       padding-right: @grid-gutter-width;

--- a/dist/origin-web-catalogs.css
+++ b/dist/origin-web-catalogs.css
@@ -596,15 +596,6 @@ body.overlay-open .landing-side-bar {
   background-size: 100% 6px;
   -webkit-overflow-scrolling: touch;
 }
-.catalogs-overlay-panel .wizard-pf-main _::-webkit-full-page-media,
-.catalogs-overlay-panel .wizard-pf-main _:future,
-:root .catalogs-overlay-panel .wizard-pf-main {
-  background-attachment: local, local, scroll, scroll;
-  background-image: linear-gradient(#ffffff 30%, rgba(255, 255, 255, 0)), linear-gradient(rgba(255, 255, 255, 0), #ffffff 70%), radial-gradient(ellipse at top, rgba(0, 0, 0, 0.25) 0%, rgba(0, 0, 0, 0) 65%), radial-gradient(ellipse at bottom, rgba(0, 0, 0, 0.25) 0%, rgba(0, 0, 0, 0) 65%);
-  background-position: 0 0, 0 100%;
-  background-repeat: no-repeat;
-  background-size: 100% 12px, 100% 12px, 100% 6px, 100% 6px;
-}
 @media (max-width: 767px) {
   .catalogs-overlay-panel .wizard-pf-main {
     bottom: 58px;
@@ -637,11 +628,6 @@ body.overlay-open .landing-side-bar {
   background-position: 0 0, 0 100%;
   background-repeat: no-repeat;
   background-size: 100% 12px;
-}
-.catalogs-overlay-panel .wizard-pf-main-inner-shadow-covers _::-webkit-full-page-media,
-.catalogs-overlay-panel .wizard-pf-main-inner-shadow-covers _:future,
-:root .catalogs-overlay-panel .wizard-pf-main-inner-shadow-covers {
-  background: none;
 }
 @media (min-width: 768px) {
   .catalogs-overlay-panel .wizard-pf-main-inner-shadow-covers {

--- a/src/styles/mixins.less
+++ b/src/styles/mixins.less
@@ -13,13 +13,3 @@
   background-repeat: no-repeat;
   background-size: 100% 12px;
 }
-
-.scroll-shadows-vertical-with-covers(@shadow-width: 75%, @shadow-opacity: 0.2, @shadow-cover-bg-color: rgba(255,255,255,1), @shadow-cover-bg-color-transparent: rgba(255,255,255,0)) {
-  background-attachment: local, local, scroll, scroll;
-  background-image:
-    linear-gradient(@shadow-cover-bg-color 30%, @shadow-cover-bg-color-transparent), linear-gradient(@shadow-cover-bg-color-transparent, @shadow-cover-bg-color 70%),
-    radial-gradient(ellipse at top, rgba(0, 0, 0, @shadow-opacity) 0%, rgba(0, 0, 0, 0) @shadow-width), radial-gradient(ellipse at bottom, rgba(0, 0, 0, @shadow-opacity) 0%, rgba(0, 0, 0, 0) @shadow-width);
-  background-position: 0 0, 0 100%;
-  background-repeat: no-repeat;
-  background-size: 100% 12px, 100% 12px, 100% 6px, 100% 6px;
-}

--- a/src/styles/overlay-panel.less
+++ b/src/styles/overlay-panel.less
@@ -67,9 +67,6 @@ body.overlay-open {
     padding: 0;
     .scroll-shadows-vertical();
     -webkit-overflow-scrolling: touch; // enable momentum scrolling in mobile Safari
-    _::-webkit-full-page-media, _:future, :root & { // only target Safari
-      .scroll-shadows-vertical-with-covers(65%, 0.25);
-    }
     @media(max-width: @screen-xs-max) {
       bottom: 58px; // height of .wizard-pf-footer
       height: auto;
@@ -97,9 +94,6 @@ body.overlay-open {
     min-height: 100%;
     padding: (@grid-gutter-width / 2);
     .scroll-shadows-vertical-covers();
-    _::-webkit-full-page-media, _:future, :root & { // only target Safari
-      background: none;
-    }
     @media(min-width: @screen-sm-min) {
       padding-left: @grid-gutter-width;
       padding-right: @grid-gutter-width;


### PR DESCRIPTION
The override fix is no longer required for Safari 11, and the override was
breaking the shadow behavior in mobile Safari now that
-webkit-overflow-scrolling: touch is enabled.