### PR TITLE
Fix bug where previous Chrome repaint bug prevented Create Project fr…

### DIFF
--- a/dist/less/landing-page.less
+++ b/dist/less/landing-page.less
@@ -197,9 +197,6 @@ landingbody,
     right: 0;
     top: @landing-side-bar-top-offset;
     width: @landing-side-bar-width-sm;
-    // force better hardware acceleration to resolve repaint bug
-    // see http://blog.getpostman.com/2015/01/23/ui-repaint-issue-on-chrome/
-    -webkit-transform: translate3d(0,0,0);
   }
   @media(min-width: @screen-lg-min) {
     width: @landing-side-bar-width-lg;

--- a/dist/less/projects-summary.less
+++ b/dist/less/projects-summary.less
@@ -29,6 +29,9 @@
   .create-button {
     font-size: @font-size-base + 1;
     float: right;
+    // force better hardware acceleration to resolve repaint bug
+    // see http://blog.getpostman.com/2015/01/23/ui-repaint-issue-on-chrome/
+    -webkit-transform: translate3d(0,0,0);
   }
 
   .create-button-text {

--- a/dist/origin-web-catalogs.css
+++ b/dist/origin-web-catalogs.css
@@ -256,7 +256,6 @@ landingbody,
     right: 0;
     top: 61px;
     width: 325px;
-    -webkit-transform: translate3d(0, 0, 0);
   }
 }
 @media (min-width: 1200px) {
@@ -714,6 +713,7 @@ body.overlay-open .landing-side-bar {
 .catalog-projects-summary-panel .create-button {
   font-size: 13px;
   float: right;
+  -webkit-transform: translate3d(0, 0, 0);
 }
 .catalog-projects-summary-panel .create-button-text {
   padding-left: 4px;

--- a/src/styles/landing-page.less
+++ b/src/styles/landing-page.less
@@ -197,9 +197,6 @@ landingbody,
     right: 0;
     top: @landing-side-bar-top-offset;
     width: @landing-side-bar-width-sm;
-    // force better hardware acceleration to resolve repaint bug
-    // see http://blog.getpostman.com/2015/01/23/ui-repaint-issue-on-chrome/
-    -webkit-transform: translate3d(0,0,0);
   }
   @media(min-width: @screen-lg-min) {
     width: @landing-side-bar-width-lg;

--- a/src/styles/projects-summary.less
+++ b/src/styles/projects-summary.less
@@ -29,6 +29,9 @@
   .create-button {
     font-size: @font-size-base + 1;
     float: right;
+    // force better hardware acceleration to resolve repaint bug
+    // see http://blog.getpostman.com/2015/01/23/ui-repaint-issue-on-chrome/
+    -webkit-transform: translate3d(0,0,0);
   }
 
   .create-button-text {


### PR DESCRIPTION
…om appearing

Moving the -webkit-transform to a child element also fixes the Chrome repaint bug, but does not prevent the Create Project modal from appearing.