### PR TITLE
Use `/overview` in projectUrlFilter

### DIFF
--- a/dist/origin-web-catalogs.js
+++ b/dist/origin-web-catalogs.js
@@ -480,7 +480,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
         return function(e, t) {
             var r, n = t || "project/";
             return r = i.isString(e) ? e : i.get(e, "metadata.name", ""), n.endsWith("/") || (n += "/"), 
-            n + r;
+            n + r + "/overview";
         };
     }
     t.__esModule = !0;

--- a/src/filters/projectUrl.ts
+++ b/src/filters/projectUrl.ts
@@ -15,6 +15,9 @@ export function projectUrlFilter () {
       baseUrl += '/';
     }
 
-    return baseUrl + projectName;
+    // Make sure to use `/overview` so that the wizard doesn't trigger a route
+    // change after "Continue to overview" is clicked when already on the
+    // overview. This causes flicker and a page reload.
+    return baseUrl + projectName + '/overview';
   };
 }


### PR DESCRIPTION
This avoids flicker when you're already on the overview and you click "Continue to project overview" in a wizard dialog.

/assign @rhamilto 