### PR TITLE
Move angular-ui-router to dev dependency and bump to latest 1.0.X

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -39,7 +39,7 @@ import {logoutPage} from './pages/logout/logoutPage';
 import {navigation} from './components/navigation/navigation.component';
 import {MockServicesModule} from './mockServices/mockServices.module';
 
-import 'angular-ui-router';
+import '@uirouter/angularjs';
 import routesConfig from './routes';
 
 import './app.less';

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,23 @@
         "@types/jquery": "3.3.0"
       }
     },
+    "@uirouter/angularjs": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@uirouter/angularjs/-/angularjs-1.0.15.tgz",
+      "integrity": "sha512-qV+fz+OV5WRNNCXfeVO7nEcSSNESXOxLC0lXM9sv+IwTW6gyiynZ2wHP7fP2ETbr20sPxtbFC+kMVLzyiw/yIg==",
+      "dev": true,
+      "requires": {
+        "@uirouter/core": "5.0.17"
+      },
+      "dependencies": {
+        "@uirouter/core": {
+          "version": "5.0.17",
+          "resolved": "https://registry.npmjs.org/@uirouter/core/-/core-5.0.17.tgz",
+          "integrity": "sha512-aJOSpaRbctGw24Mh74sonLwCyskl7KzFz7M0jRDqrd+eHZK6s/xxi4ZSNuGHRy6kF4x7195buQSJEo7u82t+rA==",
+          "dev": true
+        }
+      }
+    },
     "abbrev": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
@@ -626,11 +643,6 @@
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/angular-ui-bootstrap/-/angular-ui-bootstrap-0.14.3.tgz",
       "integrity": "sha1-2WzmBMhLvXBro0qryh1ac3bhi6Y="
-    },
-    "angular-ui-router": {
-      "version": "1.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/angular-ui-router/-/angular-ui-router-1.0.0-beta.1.tgz",
-      "integrity": "sha1-w8HXstwkKbHjDB8ZeKduVN8/Ki8="
     },
     "ansi-escapes": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "angular-schema-form": "^0.8.13",
     "angular-schema-form-bootstrap": "^0.2.0",
     "angular-ui-bootstrap": "0.14.x",
-    "angular-ui-router": "1.0.0-beta.1",
     "bootstrap": "^3.3.6",
     "font-awesome": "~4.7.0",
     "jquery": "3.2.1",
@@ -45,6 +44,7 @@
     "urijs": "1.18.0"
   },
   "devDependencies": {
+    "@uirouter/angularjs": "^1.0.0",
     "@types/angular": "~1.5.16",
     "@types/angular-mocks": "~1.5.5",
     "@types/angular-ui-router": "^1.1.40",


### PR DESCRIPTION
Fixes issue #654 

# Changes
- Fix angular-ui-router deprecation warning by moving to `@uirouter/angularjs`
- Move ui router to dev dependencies
- Update version constraint to '^1.0.0'