### PR TITLE
introducing 3scale in the middleware integration list

### DIFF
--- a/dist/origin-web-catalogs.js
+++ b/dist/origin-web-catalogs.js
@@ -356,7 +356,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             subCategories: [ {
                 id: "integration",
                 label: "Integration",
-                tags: [ "amq", "fuse", "jboss-fuse", "sso" ]
+                tags: [ "amq", "fuse", "jboss-fuse", "sso", "3scale" ]
             }, {
                 id: "process-automation",
                 label: "Process Automation",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1653,6 +1653,11 @@
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.7.tgz",
       "integrity": "sha1-WjiTlFSfIzMIdaOxUGVldPip63E="
     },
+    "bower": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.2.tgz",
+      "integrity": "sha1-rfU1KcjUrwLvJPuNU0HBQZ0z4vc="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "url-loader": "^0.5.7",
     "webpack": "2.2.0",
     "webpack-dev-server": "^2.9.2",
-    "webpack-merge": "^3.0.0"
+    "webpack-merge": "^3.0.0",
+    "bower": "^1.8.2"
   }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -36,7 +36,7 @@ var categories: any = [
     {id: 'mariadb', label: 'MariaDB', tags: ['mariadb'], icon: 'icon-mariadb'}
   ]},
   {id: 'middleware', label: 'Middleware', subCategories: [
-    {id: 'integration', label: 'Integration', tags: ['amq', 'fuse', 'jboss-fuse', 'sso']},
+    {id: 'integration', label: 'Integration', tags: ['amq', 'fuse', 'jboss-fuse', 'sso', '3scale']},
     {id: 'process-automation', label: 'Process Automation', tags: ['decisionserver', 'processserver']},
     {id: 'analytics-data', label: 'Analytics & Data', tags: ['datagrid', 'datavirt']},
     {id: 'runtimes', label: 'Runtimes & Frameworks', tags: ['eap', 'httpd', 'tomcat']}


### PR DESCRIPTION
Adding 3scale to the middleware list.

I'm assuming here that the `tags` array will match with the OS template tags.

cc @spadgett 