### PR TITLE
Set z-index to 1040 (same as .modal-backdrop), but will still appear …

### DIFF
--- a/dist/less/overlay-panel.less
+++ b/dist/less/overlay-panel.less
@@ -147,7 +147,8 @@ body.overlay-open {
   position: fixed;
   right: 0;
   top: 0;
-  z-index: @zindex-modal;
+  // Set z-index to 1040 (same as .modal-backdrop), but will still appear above .modal-backdrop because of markup structure. This enables the uib-modal background to overlay the catalog wizard modal, when both are displayed.
+  z-index: @zindex-modal-background;
   &.ng-enter {
     animation: modalSlideDown 0.3s ease-out forwards;
   }

--- a/dist/origin-web-catalogs.css
+++ b/dist/origin-web-catalogs.css
@@ -676,7 +676,7 @@ body.overlay-open .landing-side-bar {
   position: fixed;
   right: 0;
   top: 0;
-  z-index: 1050;
+  z-index: 1040;
 }
 .catalogs-overlay-panel-wrapper.ng-enter {
   animation: modalSlideDown 0.3s ease-out forwards;

--- a/src/styles/overlay-panel.less
+++ b/src/styles/overlay-panel.less
@@ -147,7 +147,8 @@ body.overlay-open {
   position: fixed;
   right: 0;
   top: 0;
-  z-index: @zindex-modal;
+  // Set z-index to 1040 (same as .modal-backdrop), but will still appear above .modal-backdrop because of markup structure. This enables the uib-modal background to overlay the catalog wizard modal, when both are displayed.
+  z-index: @zindex-modal-background;
   &.ng-enter {
     animation: modalSlideDown 0.3s ease-out forwards;
   }


### PR DESCRIPTION
…above .modal-backdrop because of markup structure. This enables the uib-modal background to overlay the catalog wizard modal, when both are displayed.
![overlay-bg](https://user-images.githubusercontent.com/1874151/37616752-49e85252-2b87-11e8-8837-f9261a4eed6e.gif)

