### PR TITLE
add mssql to databases category

### DIFF
--- a/dist/origin-web-catalogs.js
+++ b/dist/origin-web-catalogs.js
@@ -335,6 +335,11 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
                 tags: [ "mongodb" ],
                 icon: "icon-mongodb"
             }, {
+                id: "mssql",
+                label: "MS SQL",
+                tags: [ "mssql" ],
+                icon: "icon-mssql"
+            }, {
                 id: "mysql",
                 label: "MySQL",
                 tags: [ "mysql" ],

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -31,6 +31,7 @@ var categories: any = [
   ]},
   {id: 'databases', label: 'Databases', subCategories: [
     {id: 'mongodb', label: 'Mongo', tags: ['mongodb'], icon: 'icon-mongodb'},
+    {id: 'mssql', label: 'MS SQL', tags: ['mssql'], icon: 'icon-mssql'},
     {id: 'mysql', label: 'MySQL', tags: ['mysql'], icon: 'icon-mysql-database'},
     {id: 'postgresql', label: 'Postgres', tags: ['postgresql'], icon: 'icon-postgresql'},
     {id: 'mariadb', label: 'MariaDB', tags: ['mariadb'], icon: 'icon-mariadb'}


### PR DESCRIPTION
Add MS SQL subcategory to databases. Will allow the following APB to be displayed under databases in catalog:
https://github.com/ansibleplaybookbundle/mssql-apb

Depends on https://github.com/openshift/origin-web-console/pull/2941 for its image.