### PR TITLE
Allow for a 'file' type in the openshift_form_defintion.

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -24,6 +24,7 @@ require('angular-utf8-base64');
 require('hopscotch/dist/js/hopscotch.js');
 require('angular-schema-form');
 require('angular-schema-form-bootstrap');
+require('angular-schema-form-base64-file-upload');
 
 try {
   require('./config.local.js');
@@ -58,7 +59,7 @@ if (mockServicesModule.useMockServices() !== true) {
 }
 
 angular
-  .module(catalogApp, ['webCatalog', 'openshiftCommonUI', commonServices, 'ui.router', 'patternfly', 'angularMoment', 'schemaForm'])
+  .module(catalogApp, ['webCatalog', 'openshiftCommonUI', commonServices, 'ui.router', 'patternfly', 'angularMoment', 'schemaForm', 'angularSchemaFormBase64FileUpload'])
   .config(routesConfig)
   .component('oauth', oauth)
   .component('homepage', homePage)

--- a/bower.json
+++ b/bower.json
@@ -41,7 +41,8 @@
     "jquery": "~3.2.1",
     "lodash": "~4.17.4",
     "origin-web-common": ">=3.10.0-alpha.1 <3.11.0",
-    "angular-schema-form-bootstrap": "^0.2.0"
+    "angular-schema-form-bootstrap": "^0.2.0",
+    "angular-schema-form-base64-file-upload": "^1.1.2"
   },
   "devDependencies": {
     "ace-builds": "1.2.2",

--- a/dist/origin-web-catalogs.js
+++ b/dist/origin-web-catalogs.js
@@ -1175,12 +1175,23 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             this.ctrl = this;
         }
         return e.prototype.$onInit = function() {
-            this.setupFormDefaults(), this.ctrl.parameterForm = this.cloneParameterForm(this.ctrl.parameterFormDefinition) || [ "*" ], 
+            this.setupFileSchema(), this.setupFormDefaults(), this.ctrl.parameterForm = this.cloneParameterForm(this.ctrl.parameterFormDefinition) || [ "*" ], 
             this.updateHiddenModel(), this.setupReadonlySchema();
         }, e.prototype.$onChanges = function(e) {
             (e.parameterFormDefinition && !e.parameterFormDefinition.isFirstChange() || e.hideValues && !e.hideValues.isFirstChange() || e.readOnly && !e.readOnly.isFirstChange()) && (this.ctrl.parameterForm = this.cloneParameterForm(this.ctrl.parameterFormDefinition) || [ "*" ]), 
             e.isHorizontal && !e.isHorizontal.isFirstChange() && this.setupFormDefaults(), (e.hideValues && !e.hideValues.isFirstChange() || e.model && !e.model.isFirstChange()) && this.updateHiddenModel(), 
             (e.parameterSchema && !e.parameterSchema.isFirstChange() || e.readOnly && !e.readOnly.isFirstChange()) && this.setupReadonlySchema();
+        }, e.prototype.setupFileSchema = function() {
+            var e = this;
+            n.each(this.ctrl.parameterFormDefinition, function(t) {
+                n.each(n.get(t, "items"), function(t, r) {
+                    "file" === t.type && (t.type = "string", n.assign(n.get(e.ctrl.parameterSchema, [ "properties", t.key ]), {
+                        type: "string",
+                        format: "base64",
+                        maxSize: "5242880"
+                    }));
+                });
+            });
         }, e.prototype.setupFormDefaults = function() {
             this.ctrl.parameterFormDefaults = {
                 formDefaults: {
@@ -1246,7 +1257,8 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
         textarea: !0,
         password: !0,
         checkbox: !0,
-        select: !0
+        select: !0,
+        file: !0
     }, t.CatalogParametersController = a;
 }, function(e, t, r) {
     "use strict";
@@ -2374,7 +2386,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
     var n = r(1);
     r(3), r(36);
     var i = r(37), a = r(38), s = r(39), c = r(40), o = r(24), l = r(25), d = r(41), p = r(26), h = r(27), m = r(28), u = r(29), g = r(30), f = r(31), v = r(32), y = r(33), b = r(34), S = r(35), $ = r(42), P = r(23);
-    t.webCatalog = "webCatalog", n.module(t.webCatalog, [ "patternfly", "ngAnimate", "ui.bootstrap", "angularMoment", "ui.select", "schemaForm" ]).service("BuilderAppService", c.BuilderAppService).service("Catalog", d.CatalogService).service("RecentlyViewedServiceItems", $.RecentlyViewedServiceItems).filter("escapeRegExp", i.escapeRegExpFilter).filter("projectUrl", a.projectUrlFilter).filter("secretUrl", s.secretUrlFilter).component("catalogParameters", o.catalogParameters).component("catalogSearch", l.catalogSearch).component("createFromBuilder", p.createFromBuilder).component("landingPage", h.landingPage).component("orderService", m.orderService).component("overlayPanel", u.overlayPanel).component("projectsSummary", g.projectsSummary).component("saasList", f.saasList).component("selectPlan", v.selectPlan).component("selectProject", y.selectProject).component("servicesView", b.servicesView).component("updateService", S.updateService).component("catalogFilter", P.catalogFilter).run([ "$templateCache", function(e) {
+    t.webCatalog = "webCatalog", n.module(t.webCatalog, [ "patternfly", "ngAnimate", "ui.bootstrap", "angularMoment", "ui.select", "schemaForm", "angularSchemaFormBase64FileUpload" ]).service("BuilderAppService", c.BuilderAppService).service("Catalog", d.CatalogService).service("RecentlyViewedServiceItems", $.RecentlyViewedServiceItems).filter("escapeRegExp", i.escapeRegExpFilter).filter("projectUrl", a.projectUrlFilter).filter("secretUrl", s.secretUrlFilter).component("catalogParameters", o.catalogParameters).component("catalogSearch", l.catalogSearch).component("createFromBuilder", p.createFromBuilder).component("landingPage", h.landingPage).component("orderService", m.orderService).component("overlayPanel", u.overlayPanel).component("projectsSummary", g.projectsSummary).component("saasList", f.saasList).component("selectPlan", v.selectPlan).component("selectProject", y.selectProject).component("servicesView", b.servicesView).component("updateService", S.updateService).component("catalogFilter", P.catalogFilter).run([ "$templateCache", function(e) {
         e.put("catalog-search/catalog-search-result.html", r(4)), e.put("create-from-builder/create-from-builder-info.html", r(7)), 
         e.put("create-from-builder/create-from-builder-configure.html", r(6)), e.put("create-from-builder/create-from-builder-bind.html", r(5)), 
         e.put("create-from-builder/create-from-builder-results.html", r(8)), e.put("order-service/order-service-info.html", r(12)), 

--- a/package-lock.json
+++ b/package-lock.json
@@ -634,6 +634,11 @@
         "tv4": "1.0.18"
       }
     },
+    "angular-schema-form-base64-file-upload": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/angular-schema-form-base64-file-upload/-/angular-schema-form-base64-file-upload-1.1.0.tgz",
+      "integrity": "sha1-GXW+vSqp2HIQA2EJteduBua2qgY="
+    },
     "angular-schema-form-bootstrap": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/angular-schema-form-bootstrap/-/angular-schema-form-bootstrap-0.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "angular-patternfly": ">=4.11.8 <5.0.0",
     "angular-sanitize": "1.5.11",
     "angular-schema-form": "^0.8.13",
+    "angular-schema-form-base64-file-upload": "^1.1.0",
     "angular-schema-form-bootstrap": "^0.2.0",
     "angular-ui-bootstrap": "0.14.x",
     "bootstrap": "^3.3.6",

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ import {catalogFilter} from './components/catalog-filter/catalog-filter.componen
 export const webCatalog: string = 'webCatalog';
 
 angular
-  .module(webCatalog, ['patternfly', 'ngAnimate', 'ui.bootstrap', 'angularMoment', 'ui.select', 'schemaForm'])
+  .module(webCatalog, ['patternfly', 'ngAnimate', 'ui.bootstrap', 'angularMoment', 'ui.select', 'schemaForm', 'angularSchemaFormBase64FileUpload'])
   .service('BuilderAppService', BuilderAppService)
   .service('Catalog', CatalogService)
   .service('RecentlyViewedServiceItems', RecentlyViewedServiceItems)

--- a/test/utils/testHelpers.ts
+++ b/test/utils/testHelpers.ts
@@ -18,6 +18,7 @@ require('angular-utf8-base64');
 require('origin-web-common/dist/origin-web-common-ui.js');
 require('angular-schema-form');
 require('angular-schema-form-bootstrap');
+require('angular-schema-form-base64-file-upload');
 
 import '../../src/index';
 


### PR DESCRIPTION
For #674

Specifying this type in the openshift_form_defintion will trigger
the necessary schema & form setup so the parameter is shown as a
file upload input in the catalog provision/bind wizard.

The angular-schema-form add-on at https://github.com/Textalk/angular-schema-form-base64-file-upload
is used for the display of the file upload input.
The file uploaded is converted to base64 and stored as a string
parameter upon provsion/bind.

![image](https://user-images.githubusercontent.com/878251/39186141-6bc04f96-47c1-11e8-9bae-0d308a4f3359.png)

Example plan with 'file' upload type
https://gist.github.com/david-martin/b5ddbdb843e9d2285ee823ed0f355fba#file-serviceclass-json-L36

Example base64 string (data-url) that gets set by the add-on
```
"file:10.201.82.242.file:mycert.txt;data:text/plain;base64,Zm9vYmFyCg=="
```