### PR TITLE
Update components/update-service to update secret parameters in place

### DIFF
--- a/dist/origin-web-catalogs.js
+++ b/dist/origin-web-catalogs.js
@@ -394,11 +394,11 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             } ]
         } ];
         n.set(window, "OPENSHIFT_CONSTANTS.SERVICE_CATALOG_CATEGORIES", s), n.set(window, "OPENSHIFT_CONSTANTS.SAAS_OFFERINGS", a);
-        var c = {
+        var o = {
             pod_presets: !1
         };
-        n.set(window, "OPENSHIFT_CONSTANTS.ENABLE_TECH_PREVIEW_FEATURE", c);
-        var o = {
+        n.set(window, "OPENSHIFT_CONSTANTS.ENABLE_TECH_PREVIEW_FEATURE", o);
+        var c = {
             links: [ {
                 title: "Documentation",
                 help: ""
@@ -416,7 +416,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
                 href: "https://blog.openshift.com"
             } ]
         };
-        n.set(window, "OPENSHIFT_CONSTANTS.CATALOG_HELP_RESOURCES", o);
+        n.set(window, "OPENSHIFT_CONSTANTS.CATALOG_HELP_RESOURCES", c);
         var l = function() {
             e("body").find(".services-view-container .nav-tabs a")[0].click();
         }, d = function() {
@@ -713,7 +713,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             this.logger = a;
         }
         return e.prototype.getCatalogItems = function(e) {
-            var t = this, r = this.$q.defer(), n = {}, a = 0, s = 0, c = [], o = function() {
+            var t = this, r = this.$q.defer(), n = {}, a = 0, s = 0, o = [], c = function() {
                 if (e) {
                     ++a;
                     var i = t.apiService.getPreferredVersion("templates");
@@ -724,9 +724,9 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
                     }).then(function(e) {
                         n.templates = e.by("metadata.name");
                     }, function() {
-                        c.push("templates");
+                        o.push("templates");
                     }).finally(function() {
-                        t.returnCatalogItems(r, n, ++s, a, c);
+                        t.returnCatalogItems(r, n, ++s, a, o);
                     });
                 }
             }, l = this.apiService.getPreferredVersion("clusterserviceclasses");
@@ -737,23 +737,23 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
                     }
                 });
             }, function() {
-                c.push("service classes");
+                o.push("service classes");
             }).finally(function() {
                 i.some(n.serviceClasses, {
                     spec: {
                         clusterServiceBrokerName: "template-service-broker"
                     }
-                }) || o(), t.returnCatalogItems(r, n, ++s, a, c);
-            })) : o(), ++a;
+                }) || c(), t.returnCatalogItems(r, n, ++s, a, o);
+            })) : c(), ++a;
             var d = this.apiService.getPreferredVersion("imagestreams");
             return this.dataService.list(d, {
                 namespace: "openshift"
             }).then(function(e) {
                 n.imageStreams = e.by("metadata.name");
             }, function() {
-                c.push("builder images");
+                o.push("builder images");
             }).finally(function() {
-                t.returnCatalogItems(r, n, ++s, a, c);
+                t.returnCatalogItems(r, n, ++s, a, o);
             }), r.promise;
         }, e.prototype.getServicePlansForServiceClass = function(e) {
             var t = this.apiService.getPreferredVersion("clusterserviceplans"), r = i.isString(e) ? e : i.get(e, "metadata.name");
@@ -779,16 +779,16 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             var a = this.$q.defer(), s = {
                 imageStreams: [],
                 templates: []
-            }, c = 0, o = 0, l = [], d = this.apiService.getPreferredVersion("imagestreams"), p = this.apiService.getPreferredVersion("templates");
-            return t && (c++, this.dataService.list(d, {
+            }, o = 0, c = 0, l = [], d = this.apiService.getPreferredVersion("imagestreams"), p = this.apiService.getPreferredVersion("templates");
+            return t && (o++, this.dataService.list(d, {
                 namespace: e
             }).then(function(e) {
                 s.imageStreams = e.by("metadata.name");
             }, function() {
                 l.push("builder images");
             }).finally(function() {
-                i.returnCatalogItems(a, s, ++o, c, l);
-            })), r && (c++, this.dataService.list(p, {
+                i.returnCatalogItems(a, s, ++c, o, l);
+            })), r && (o++, this.dataService.list(p, {
                 namespace: e
             }, null, {
                 partialObjectMetadataList: n
@@ -797,7 +797,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             }, function() {
                 l.push("templates");
             }).finally(function() {
-                i.returnCatalogItems(a, s, ++o, c, l);
+                i.returnCatalogItems(a, s, ++c, o, l);
             })), a.promise;
         }, e.prototype.sortCatalogItems = function(e) {
             return e.sort(function(e, t) {
@@ -822,9 +822,9 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
         }, e.prototype.getServiceItem = function(e) {
             return new s(e, this);
         }, e.prototype.getImageItem = function(e) {
-            return new c(e, this);
-        }, e.prototype.getTemplateItem = function(e) {
             return new o(e, this);
+        }, e.prototype.getTemplateItem = function(e) {
+            return new c(e, this);
         }, e.prototype.getPublisherSynonym = function(e) {
             return i.get(this.constants, [ "PUBLISHER_SYNONYMS", e ]) || e;
         }, e.prototype.normalizeIconClass = function(e) {
@@ -834,7 +834,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
         }, e.prototype.categorizeItems = function(e) {
             var t, r, a = this, s = n.copy(this.constants.SERVICE_CATALOG_CATEGORIES);
             this.createAllAndOtherMainCategories(s);
-            var c = i.head(s), o = i.get(c, "subCategories[0]"), l = i.last(s), d = i.get(l, "subCategories[0]");
+            var o = i.head(s), c = i.get(o, "subCategories[0]"), l = i.last(s), d = i.get(l, "subCategories[0]");
             return i.each(e, function(e) {
                 r = !1, i.each(s, function(n) {
                     n.tags ? a.hasMatchingTags(n.tags, e.tags) && (r = a.categorizeItem(e, n, "all"), 
@@ -844,7 +844,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
                     i.each(t, function(t) {
                         a.categorizeItem(e, n, t);
                     })));
-                }), r || a.categorizeItem(e, l, d), a.categorizeItem(e, c, o);
+                }), r || a.categorizeItem(e, l, d), a.categorizeItem(e, o, c);
             }), s;
         }, e.prototype.getVendors = function(e) {
             var t = {};
@@ -936,7 +936,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
         }, e;
     }();
     t.ServiceItem = s;
-    var c = function() {
+    var o = function() {
         function e(e, t) {
             this.resource = e, this.catalogSrv = t, this.builderSpecTagName = this.getBuilderSpecTagName(), 
             this.builderSpecTagName ? (this.tags = this.getTags(), this.imageUrl = this.getImage(), 
@@ -972,8 +972,8 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             return null;
         }, e;
     }();
-    t.ImageItem = c;
-    var o = function() {
+    t.ImageItem = o;
+    var c = function() {
         function e(e, t) {
             this.resource = e, this.catalogSrv = t, this.imageUrl = this.getImage(), this.iconClass = this.getIcon(), 
             this.name = this.getName(), this.description = this.getDescription(), this.longDescription = this.getLongDescription(), 
@@ -999,7 +999,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             return this.catalogSrv.getPublisherSynonym(e);
         }, e;
     }();
-    t.TemplateItem = o;
+    t.TemplateItem = c;
 }, function(e, t, r) {
     "use strict";
     t.__esModule = !0;
@@ -1253,11 +1253,11 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
     t.__esModule = !0;
     var n = r(0), i = r(2), a = function() {
         function e(e, t, r, n, i, a, s) {
-            var c = this;
+            var o = this;
             this.ctrl = this, this.loaded = !1, this.maxResultsToShow = 5, this.onKeyPress = function(e) {
-                13 === e.which && c.ctrl.searchText && (c.$rootScope.$emit("filter-catalog-items", {
-                    searchText: c.ctrl.searchText
-                }), c.ctrl.searchText = "");
+                13 === e.which && o.ctrl.searchText && (o.$rootScope.$emit("filter-catalog-items", {
+                    searchText: o.ctrl.searchText
+                }), o.ctrl.searchText = "");
             }, this.$rootScope = e, this.$scope = t, this.$timeout = r, this.$q = n, this.Catalog = i, 
             this.Constants = a, this.KeywordService = s;
         }
@@ -1308,7 +1308,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
     "use strict";
     t.__esModule = !0;
     var n = r(1), i = r(0), a = r(69), s = function() {
-        function e(e, t, r, n, a, s, c, o, l, d, p, h) {
+        function e(e, t, r, n, a, s, o, c, l, d, p, h) {
             var m = this;
             this.ctrl = this, this.watches = [], this.clearValidityWatcher = function() {
                 m.validityWatcher && (m.validityWatcher(), m.validityWatcher = void 0);
@@ -1343,9 +1343,9 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             }, this.isServiceBindable = function(e) {
                 var t, r = m.BindingService.getServiceClassForInstance(e, m.ctrl.serviceClasses), n = i.get(e, "spec.clusterServicePlanRef.name");
                 return n && (t = m.ctrl.servicePlans[n]), m.BindingService.isServiceBindable(e, r, t);
-            }, this.$scope = n, this.$filter = e, this.$location = t, this.$q = r, this.BuilderAppService = c, 
+            }, this.$scope = n, this.$filter = e, this.$location = t, this.$q = r, this.BuilderAppService = o, 
             this.ProjectsService = p, this.DataService = l, this.APIService = a, this.BindingService = s, 
-            this.Logger = d, this.VersionsService = h, this.ctrl.serviceToBind = null, this.ctrl.showPodPresets = i.get(o, [ "ENABLE_TECH_PREVIEW_FEATURE", "pod_presets" ], !1), 
+            this.Logger = d, this.VersionsService = h, this.ctrl.serviceToBind = null, this.ctrl.showPodPresets = i.get(c, [ "ENABLE_TECH_PREVIEW_FEATURE", "pod_presets" ], !1), 
             this.gitRef = "", this.contextDir = "";
         }
         return e.prototype.$onInit = function() {
@@ -1445,8 +1445,8 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
                 var a = e.getTagReference(n);
                 if (a) return t[n.name] = a, e.ctrl.referencedBy[a] = e.ctrl.referencedBy[a] || [], 
                 void e.ctrl.referencedBy[a].push(n.name);
-                var s = i.get(n, "annotations.tags", ""), c = s.split(/\s*,\s*/);
-                i.includes(c, "builder") && !i.includes(c, "hidden") && (r[n.name] = n);
+                var s = i.get(n, "annotations.tags", ""), o = s.split(/\s*,\s*/);
+                i.includes(o, "builder") && !i.includes(o, "hidden") && (r[n.name] = n);
             });
             var a = [], s = i.get(this, "ctrl.imageStream.resource.status.tags", []);
             return i.each(s, function(e) {
@@ -1577,7 +1577,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
     "use strict";
     t.__esModule = !0;
     var n = r(1), i = r(0), a = function() {
-        function e(e, t, r, n, a, s, c, o, l, d) {
+        function e(e, t, r, n, a, s, o, c, l, d) {
             var p = this;
             this.ctrl = this, this.watches = [], this.clearValidityWatcher = function() {
                 p.validityWatcher && (p.validityWatcher(), p.validityWatcher = void 0), p.ctrl.reviewStep.allowed = !1;
@@ -1641,7 +1641,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
                     });
                 }));
             }, this.$scope = e, this.$filter = t, this.APIService = r, this.ApplicationsService = n, 
-            this.ProjectsService = a, this.DataService = s, this.BindingService = c, this.Logger = o, 
+            this.ProjectsService = a, this.DataService = s, this.BindingService = o, this.Logger = c, 
             this.ctrl.showPodPresets = i.get(l, [ "ENABLE_TECH_PREVIEW_FEATURE", "pod_presets" ], !1), 
             this.DNS1123_SUBDOMAIN_VALIDATION = d;
         }
@@ -1733,8 +1733,8 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             this.DataService.create(a, null, n, s).then(function(n) {
                 if (e.ctrl.orderInProgress = !0, e.watchResults(a, n, s), e.ctrl.serviceInstance = n, 
                 r) {
-                    var c = e.BindingService.makeParametersSecret(r, t, n), o = e.APIService.getPreferredVersion("secrets");
-                    e.DataService.create(o, null, c, s).then(i.noop, function(t) {
+                    var o = e.BindingService.makeParametersSecret(r, t, n), c = e.APIService.getPreferredVersion("secrets");
+                    e.DataService.create(c, null, o, s).then(i.noop, function(t) {
                         e.ctrl.error = i.get(t, "data");
                     });
                 }
@@ -1836,7 +1836,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
     "use strict";
     t.__esModule = !0;
     var n = r(1), i = r(0), a = function() {
-        function e(t, r, a, s, c, o, l, d, p, h, m) {
+        function e(t, r, a, s, o, c, l, d, p, h, m) {
             var u = this;
             this.ctrl = this, this.newProjectPanelShown = !1, this.editProjectPanelShown = !1, 
             this.watches = [], this.maxDisplayProjects = 5, this.watchingProjects = !1, this.init = function() {
@@ -1874,8 +1874,8 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
                 u.ctrl.editProjectPanelShown = !1, u.watchingProjects || u.ProjectsService.list().then(u.onProjectsUpdate);
             }, this.onDeleteProject = function() {
                 u.watchingProjects || u.ProjectsService.list().then(u.onProjectsUpdate);
-            }, this.$filter = t, this.$rootScope = r, this.$scope = a, this.$window = s, this.AuthService = c, 
-            this.Constants = o, this.DataService = l, this.Logger = d, this.ProjectsService = p, 
+            }, this.$filter = t, this.$rootScope = r, this.$scope = a, this.$window = s, this.AuthService = o, 
+            this.Constants = c, this.DataService = l, this.Logger = d, this.ProjectsService = p, 
             this.RecentlyViewedProjectsService = h, this.RecentlyViewedItems = m;
         }
         return e.prototype.$onInit = function() {
@@ -1985,7 +1985,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
     "use strict";
     t.__esModule = !0;
     var n = r(1), i = r(0), a = function() {
-        function e(t, r, n, a, s, c, o, l) {
+        function e(t, r, n, a, s, o, c, l) {
             var d = this;
             this.ctrl = this, this.getProjectChoices = function() {
                 return d.ctrl.matchingProjects ? d.ctrl.matchingProjects : d.largeProjectList ? [] : d.projects;
@@ -2001,7 +2001,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
                     e = d.AuthorizationService.canIAddToProject(t), d.ctrl.forms && d.ctrl.forms.selectProjectForm.selectProject.$setValidity("cannotAddToProject", e);
                 }), d.ctrl.forms && d.ctrl.forms.selectProjectForm.selectProject.$setValidity("cannotAddToProject", e);
             }, this.$filter = t, this.$scope = r, this.AuthService = n, this.AuthorizationService = a, 
-            this.KeywordService = s, this.Logger = c, this.ProjectsService = o, this.RecentlyViewedProjectsService = l, 
+            this.KeywordService = s, this.Logger = o, this.ProjectsService = c, this.RecentlyViewedProjectsService = l, 
             this.largeProjectList = !1, this.lastSearch = "", this.lastResults = [];
         }
         return e.prototype.$onInit = function() {
@@ -2084,7 +2084,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
     "use strict";
     t.__esModule = !0;
     var n = r(0), i = r(2), a = function() {
-        function e(e, t, r, i, a, s, c, o, l, d) {
+        function e(e, t, r, i, a, s, o, c, l, d) {
             var p = this;
             this.ctrl = this, this.previousSubCategoryHeight = 0, this.resizeRetries = 0, this.serviceViewItemClicked = function(e, t) {
                 p.$scope.$emit("open-overlay-panel", e);
@@ -2102,7 +2102,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             }, this.clearAppliedFilters = function() {
                 p.$scope.$broadcast("clear-filters");
             }, this.constants = e, this.catalog = t, this.keywordService = r, this.logger = i, 
-            this.htmlService = a, this.element = s[0], this.$filter = c, this.$rootScope = o, 
+            this.htmlService = a, this.element = s[0], this.$filter = o, this.$rootScope = c, 
             this.$scope = l, this.$timeout = d, this.ctrl.loaded = !1, this.ctrl.isEmpty = !1, 
             this.ctrl.mobileView = "categories", this.ctrl.filterConfig = {
                 resultsLabel: "Items",
@@ -2222,7 +2222,7 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
     "use strict";
     t.__esModule = !0;
     var n = r(1), i = r(0), a = function() {
-        function e(e, t, r, a, s, c, o, l) {
+        function e(e, t, r, a, s, o, c, l) {
             var d = this;
             this.ctrl = this, this.configChanged = !0, this.secrets = [], this.clearValidityWatcher = function() {
                 d.validityWatcher && (d.validityWatcher(), d.validityWatcher = void 0), d.ctrl.reviewStep.allowed = !1;
@@ -2250,37 +2250,16 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
                 d.ctrl.orderComplete = !1, d.ctrl.error = null;
                 var e = d.getParameters(d.ctrl.parameterData), t = i.get(d.ctrl.serviceInstance, "spec.parameters"), r = i.map(t, function(e, t) {
                     return [ t ];
-                }), a = i.pick(e, r), s = i.omit(e, r), c = n.copy(d.ctrl.serviceInstance);
-                i.get(c, "spec.clusterServicePlanExternalName") !== i.get(d.ctrl.selectedPlan, "spec.externalName") && (i.unset(c, "spec.clusterServicePlanRef"), 
-                i.set(c, "spec.clusterServicePlanExternalName", i.get(d.ctrl.selectedPlan, "spec.externalName"))), 
-                n.equals(a, t) || i.set(c, "spec.parameters", a);
-                var o = {};
-                if (i.each(d.secrets, function(t) {
-                    var r = JSON.parse(d.SecretsService.decodeSecretData(t.data).parameters), a = i.map(r, function(e, t) {
-                        return [ t ];
-                    }), l = i.pick(e, a);
-                    s = i.omit(s, a), n.equals(l, r) || (n.extend(o, l), c.spec.parametersFrom = i.reject(c.spec.parametersFrom, {
-                        secretKeyRef: {
-                            name: t.metadata.name
-                        }
-                    }));
-                }), n.extend(o, s), i.isEmpty(o)) d.updateServiceInstance(c); else {
-                    var l = d.BindingService.generateSecretName(i.get(d.ctrl.serviceClass, "spec.externalName"));
-                    c.spec.parametersFrom.push({
-                        secretKeyRef: {
-                            name: l,
-                            key: "parameters"
-                        }
-                    });
-                    var p = d.BindingService.makeParametersSecret(l, o, c), h = d.APIService.getPreferredVersion("secrets");
-                    d.DataService.create(h, null, p, d.context).then(function() {
-                        d.updateServiceInstance(c);
-                    }, function(e) {
-                        d.ctrl.error = i.get(e, "data");
-                    });
-                }
+                }), a = i.pick(e, r), s = i.omit(e, r), o = n.copy(d.ctrl.serviceInstance);
+                d.updateServicePlanName(o), d.updateSpecParameters(o, a, t);
+                var c = d.updateSecretParameters(o, s);
+                d.updateSecret(o, c).then(function() {
+                    d.updateServiceInstance(o);
+                }, function(e) {
+                    d.ctrl.error = i.get(e, "data");
+                });
             }, this.$scope = e, this.$filter = t, this.$q = r, this.APIService = a, this.BindingService = s, 
-            this.DataService = c, this.Logger = o, this.SecretsService = l;
+            this.DataService = o, this.Logger = c, this.SecretsService = l;
         }
         return e.prototype.$onInit = function() {
             var e = this;
@@ -2337,6 +2316,20 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
             this.clearValidityWatcher(), this.dataWatcher && this.dataWatcher(), this.progressWatcher && this.DataService.unwatch(this.progressWatcher);
         }, e.prototype.closePanel = function() {
             n.isFunction(this.ctrl.handleClose) && this.ctrl.handleClose();
+        }, e.prototype.updateServicePlanName = function(e) {
+            i.get(e, "spec.clusterServicePlanExternalName") !== i.get(this.ctrl.selectedPlan, "spec.externalName") && (i.unset(e, "spec.clusterServicePlanRef"), 
+            i.set(e, "spec.clusterServicePlanExternalName", i.get(this.ctrl.selectedPlan, "spec.externalName")));
+        }, e.prototype.updateSpecParameters = function(e, t, r) {
+            n.equals(t, r) || i.set(e, "spec.parameters", t);
+        }, e.prototype.updateSecretParameters = function(e, t) {
+            var r = this, n = {};
+            return i.each(this.secrets, function(e) {
+                var a = JSON.parse(r.SecretsService.decodeSecretData(e.data).parameters);
+                i.assign(n, a, t);
+            }), n;
+        }, e.prototype.updateSecret = function(e, t) {
+            var r = i.get(i.head(e.spec.parametersFrom), "secretKeyRef.name"), n = this.BindingService.makeParametersSecret(r, t, e), a = this.APIService.getPreferredVersion("secrets");
+            return this.DataService.update(a, r, n, this.context);
         }, e.prototype.updateParameterSchema = function(e) {
             this.ctrl.parameterSchema = i.get(e, "spec.instanceUpdateParameterSchema"), this.ctrl.parameterFormDefinition = i.get(e, "spec.externalMetadata.schemas.service_instance.update.openshift_form_definition");
             var t = i.get(this.ctrl.parameterSchema, "properties");
@@ -2373,8 +2366,8 @@ webpackJsonp([ 0, 1 ], [ function(e, t) {
     t.__esModule = !0;
     var n = r(1);
     r(3), r(36);
-    var i = r(37), a = r(38), s = r(39), c = r(40), o = r(24), l = r(25), d = r(41), p = r(26), h = r(27), m = r(28), u = r(29), g = r(30), f = r(31), v = r(32), y = r(33), b = r(34), S = r(35), $ = r(42), P = r(23);
-    t.webCatalog = "webCatalog", n.module(t.webCatalog, [ "patternfly", "ngAnimate", "ui.bootstrap", "angularMoment", "ui.select", "schemaForm" ]).service("BuilderAppService", c.BuilderAppService).service("Catalog", d.CatalogService).service("RecentlyViewedServiceItems", $.RecentlyViewedServiceItems).filter("escapeRegExp", i.escapeRegExpFilter).filter("projectUrl", a.projectUrlFilter).filter("secretUrl", s.secretUrlFilter).component("catalogParameters", o.catalogParameters).component("catalogSearch", l.catalogSearch).component("createFromBuilder", p.createFromBuilder).component("landingPage", h.landingPage).component("orderService", m.orderService).component("overlayPanel", u.overlayPanel).component("projectsSummary", g.projectsSummary).component("saasList", f.saasList).component("selectPlan", v.selectPlan).component("selectProject", y.selectProject).component("servicesView", b.servicesView).component("updateService", S.updateService).component("catalogFilter", P.catalogFilter).run([ "$templateCache", function(e) {
+    var i = r(37), a = r(38), s = r(39), o = r(40), c = r(24), l = r(25), d = r(41), p = r(26), h = r(27), m = r(28), u = r(29), g = r(30), f = r(31), v = r(32), y = r(33), b = r(34), S = r(35), $ = r(42), P = r(23);
+    t.webCatalog = "webCatalog", n.module(t.webCatalog, [ "patternfly", "ngAnimate", "ui.bootstrap", "angularMoment", "ui.select", "schemaForm" ]).service("BuilderAppService", o.BuilderAppService).service("Catalog", d.CatalogService).service("RecentlyViewedServiceItems", $.RecentlyViewedServiceItems).filter("escapeRegExp", i.escapeRegExpFilter).filter("projectUrl", a.projectUrlFilter).filter("secretUrl", s.secretUrlFilter).component("catalogParameters", c.catalogParameters).component("catalogSearch", l.catalogSearch).component("createFromBuilder", p.createFromBuilder).component("landingPage", h.landingPage).component("orderService", m.orderService).component("overlayPanel", u.overlayPanel).component("projectsSummary", g.projectsSummary).component("saasList", f.saasList).component("selectPlan", v.selectPlan).component("selectProject", y.selectProject).component("servicesView", b.servicesView).component("updateService", S.updateService).component("catalogFilter", P.catalogFilter).run([ "$templateCache", function(e) {
         e.put("catalog-search/catalog-search-result.html", r(4)), e.put("create-from-builder/create-from-builder-info.html", r(7)), 
         e.put("create-from-builder/create-from-builder-configure.html", r(6)), e.put("create-from-builder/create-from-builder-bind.html", r(5)), 
         e.put("create-from-builder/create-from-builder-results.html", r(8)), e.put("order-service/order-service-info.html", r(12)), 

--- a/tslint.json
+++ b/tslint.json
@@ -65,7 +65,8 @@
     "typedef-whitespace": [true,
       ["callSignature", "noSpace"],
       ["catchClause", "noSpace"],
-      ["indexSignature", "space"]
+      ["indexSignature", "space"],
+      [ "variable-declaration", "nospace"]
     ],
     "use-strict": false,
     "variable-name": false,


### PR DESCRIPTION
Fixes [bugzilla 1564979](https://bugzilla.redhat.com/show_bug.cgi?id=1564979)
- Updates `components/update-service` to update a secret in place rather than creating a new secret.

Attempted to break this massive function down into something a bit easier to maintain. Typescript is interesting, not sure I'm sold yet (but working on it), struggled with a type `string[][]` that didn't work (see `note`).  Made some other minor changes like using `let` instead of `var`, etc. 

Attempted to update types, but `object` only works on a very simple object, TypeScript seems to think a multidimensional object should have a custom type def.  That would be a good bit of work to update throughout the codebase I think.

Compiler complains about this a lot:

![screen shot 2018-05-15 at 11 40 02 am](https://user-images.githubusercontent.com/280512/40067679-bb3cbec8-5834-11e8-84d7-e4eac32c181f.png)

For some reason I prefer the first:

```JavaScript 
// :)
let foo:object = { };
// :/
let foo: object = {};
```
But I can update this && add the space to make it happy.
